### PR TITLE
Fix JSON parsing failure when writing HTML pages to Flipper

### DIFF
--- a/app/src/main/java/com/vesper/flipper/ai/OpenRouterClient.kt
+++ b/app/src/main/java/com/vesper/flipper/ai/OpenRouterClient.kt
@@ -817,7 +817,7 @@ class OpenRouterClient @Inject constructor(
         private const val MAX_TOOL_CALLS_PER_RESPONSE = 1
         private const val TOOL_UNSUPPORTED_CACHE_MS = 5 * 60 * 1000L
         private const val MAX_CONTEXT_MESSAGES = 24
-        private const val TOOL_CALL_RESPONSE_MAX_TOKENS = 320
+        private const val TOOL_CALL_RESPONSE_MAX_TOKENS = 4096
         private const val DEFAULT_RESPONSE_MAX_TOKENS = 720
 
         private val SUPPORTED_ACTIONS = listOf(

--- a/app/src/main/java/com/vesper/flipper/web/WebFileServer.kt
+++ b/app/src/main/java/com/vesper/flipper/web/WebFileServer.kt
@@ -444,7 +444,7 @@ main { padding: 16px; }
                 sendJsonResponse(writer, "{\"error\":\"Failed to list directory\"}")
             }
         } catch (e: Exception) {
-            sendJsonResponse(writer, "{\"error\":\"${e.message}\"}")
+            sendJsonResponse(writer, "{\"error\":\"${jsonEscape(e.message ?: "Unknown error")}\"}")
         }
     }
 
@@ -466,7 +466,7 @@ main { padding: 16px; }
                 sendJsonResponse(writer, "{\"error\":\"Failed to read file\"}")
             }
         } catch (e: Exception) {
-            sendJsonResponse(writer, "{\"error\":\"${e.message}\"}")
+            sendJsonResponse(writer, "{\"error\":\"${jsonEscape(e.message ?: "Unknown error")}\"}")
         }
     }
 
@@ -508,7 +508,7 @@ main { padding: 16px; }
                 sendJsonResponse(writer, "{\"error\":\"Failed to delete\"}")
             }
         } catch (e: Exception) {
-            sendJsonResponse(writer, "{\"error\":\"${e.message}\"}")
+            sendJsonResponse(writer, "{\"error\":\"${jsonEscape(e.message ?: "Unknown error")}\"}")
         }
     }
 
@@ -523,7 +523,7 @@ main { padding: 16px; }
                 sendJsonResponse(writer, "{\"error\":\"Failed to create directory\"}")
             }
         } catch (e: Exception) {
-            sendJsonResponse(writer, "{\"error\":\"${e.message}\"}")
+            sendJsonResponse(writer, "{\"error\":\"${jsonEscape(e.message ?: "Unknown error")}\"}")
         }
     }
 
@@ -584,7 +584,7 @@ main { padding: 16px; }
                 val targetPath = "${flipperPath.trimEnd('/')}/$safeName"
                 val writeResult = flipperFileSystem.writeFileBytes(targetPath, fileBytes)
                 if (writeResult.isFailure) {
-                    sendJsonResponse(writer, "{\"error\":\"Failed to write $safeName\"}")
+                    sendJsonResponse(writer, "{\"error\":\"Failed to write ${jsonEscape(safeName)}\"}")
                     return
                 }
 
@@ -601,7 +601,7 @@ main { padding: 16px; }
                 sendJsonResponse(writer, "{\"error\":\"No files found in upload\"}")
             }
         } catch (e: Exception) {
-            sendJsonResponse(writer, "{\"error\":\"${e.message}\"}")
+            sendJsonResponse(writer, "{\"error\":\"${jsonEscape(e.message ?: "Unknown error")}\"}")
         }
     }
 
@@ -692,7 +692,12 @@ main { padding: 16px; }
     }
 
     private fun jsonEscape(value: String): String {
-        return value.replace("\\", "\\\\").replace("\"", "\\\"")
+        return value
+            .replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+            .replace("\t", "\\t")
     }
 
     private fun serve404(writer: PrintWriter) {


### PR DESCRIPTION
The root cause was TOOL_CALL_RESPONSE_MAX_TOKENS being set to only 320 tokens. When the AI model generates a write_file tool call containing HTML content (e.g., Evil Portal pages), the response gets truncated mid-JSON, producing "Unexpected json tokens at offset" parse errors.

Increased the limit to 4096 to accommodate HTML payloads.

Also fixed WebFileServer.kt JSON construction:
- jsonEscape() now handles newlines, carriage returns, and tabs
- All error responses now properly escape e.message to prevent malformed JSON when exceptions contain special characters

https://claude.ai/code/session_01B9CtX7SJ6DDp6MkfBGUvCb