### PR TITLE
Fix missing 'path' parameter in LootClassifier calls and remove dupli…

### DIFF
--- a/app/src/main/java/com/vesper/flipper/domain/executor/CommandExecutor.kt
+++ b/app/src/main/java/com/vesper/flipper/domain/executor/CommandExecutor.kt
@@ -730,7 +730,7 @@ class CommandExecutor @Inject constructor(
         // Determine the payload type and generate appropriate file content
         val resolvedType = payloadType?.uppercase()?.let {
             runCatching { PayloadType.valueOf(it) }.getOrNull()
-        } ?: LootClassifier.detectPayloadType(prompt)
+        } ?: LootClassifier.detectPayloadType(prompt, "")
 
         val blueprint = generateForgeBlueprint(prompt, resolvedType)
 
@@ -911,13 +911,13 @@ class CommandExecutor @Inject constructor(
                     .filter { entry ->
                         if (filter.isNullOrEmpty()) true
                         else {
-                            val type = LootClassifier.detectPayloadType(entry.name)
+                            val type = LootClassifier.detectPayloadType(entry.name, dir)
                             type.name.equals(filter, ignoreCase = true)
                         }
                     }
                 entries.forEach { entry ->
-                    val type = LootClassifier.detectPayloadType(entry.name)
-                    val rarity = LootClassifier.classifyRarity(entry.name, entry.size, dir)
+                    val type = LootClassifier.detectPayloadType(entry.name, dir)
+                    val rarity = LootClassifier.classifyRarity(type, emptyMap())
                     allEntries.add("${entry.name} | type=${type.name.lowercase()} | rarity=${rarity.name.lowercase()} | size=${entry.size}B | path=${entry.path}")
                 }
             }

--- a/app/src/main/java/com/vesper/flipper/domain/model/Payload.kt
+++ b/app/src/main/java/com/vesper/flipper/domain/model/Payload.kt
@@ -3,13 +3,7 @@ package com.vesper.flipper.domain.model
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-/**
- * Payload types supported by the Payload Lab
- */
-enum class PayloadType {
-    BADUSB,
-    EVIL_PORTAL
-}
+// PayloadType is defined in Alchemy.kt with full Flipper type support
 
 /**
  * BadUSB script payload


### PR DESCRIPTION
…cate PayloadType enum

CommandExecutor.kt called LootClassifier.detectPayloadType() with one arg but the Alchemy.kt definition requires two (fileName, path). Also called classifyRarity() with (String, Long, String) instead of (PayloadType, Map). Fixed all call sites. Removed the old duplicate PayloadType enum from Payload.kt (BADUSB/EVIL_PORTAL) that conflicts with the new one in Alchemy.kt.

https://claude.ai/code/session_01B9CtX7SJ6DDp6MkfBGUvCb