### PR TITLE
Fix unresolved SecondaryIndicator reference in FapHubScreen

### DIFF
--- a/app/src/main/java/com/vesper/flipper/ui/screen/FapHubScreen.kt
+++ b/app/src/main/java/com/vesper/flipper/ui/screen/FapHubScreen.kt
@@ -87,7 +87,7 @@ fun FapHubScreen(
                 containerColor = Color.Transparent,
                 contentColor = Color.White,
                 indicator = { tabPositions ->
-                    TabRowDefaults.SecondaryIndicator(
+                    TabRowDefaults.Indicator(
                         modifier = Modifier.tabIndicatorOffset(tabPositions[if (activeTab == HubTab.APPS) 0 else 1]),
                         color = VesperOrange
                     )


### PR DESCRIPTION
SecondaryIndicator was added in Material 3 v1.2.0-alpha01, but the project uses Compose BOM 2023.10.01 (Material 3 v1.1.2). Replace with TabRowDefaults.Indicator which is available in v1.1.x.

https://claude.ai/code/session_01B9CtX7SJ6DDp6MkfBGUvCb