### PR TITLE
Fix unresolved tabIndicatorOffset reference in FapHubScreen

### DIFF
--- a/app/src/main/java/com/vesper/flipper/ui/screen/FapHubScreen.kt
+++ b/app/src/main/java/com/vesper/flipper/ui/screen/FapHubScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
+import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier


### PR DESCRIPTION
The wildcard import `androidx.compose.material3.*` doesn't pick up extension functions from companion objects. Added explicit import for `TabRowDefaults.tabIndicatorOffset`.

https://claude.ai/code/session_01B9CtX7SJ6DDp6MkfBGUvCb