### PR TITLE
Fix unresolved reference: use modifiedTimestamp instead of modified

### DIFF
--- a/app/src/main/java/com/vesper/flipper/ui/viewmodel/AlchemyLabViewModel.kt
+++ b/app/src/main/java/com/vesper/flipper/ui/viewmodel/AlchemyLabViewModel.kt
@@ -288,7 +288,7 @@ class AlchemyLabViewModel @Inject constructor(
                                     rarity = rarity,
                                     metadata = metadata,
                                     size = entry.size,
-                                    capturedAt = entry.modified,
+                                    capturedAt = entry.modifiedTimestamp ?: System.currentTimeMillis(),
                                     tags = tags,
                                     previewData = preview
                                 )


### PR DESCRIPTION
FileEntry has modifiedTimestamp (Long?), not modified. Falls back to current time when the timestamp is null.

https://claude.ai/code/session_01B9CtX7SJ6DDp6MkfBGUvCb