### PR TITLE
feat: add MiniMax as alternative LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,11 @@ Every action the AI takes is logged:
 
 ## Recommended AI Models
 
-Vesper works with any model on [OpenRouter](https://openrouter.ai). For the best experience:
+Vesper supports two LLM providers — choose in **Settings > LLM Provider**:
+
+### OpenRouter (default)
+
+Access 200+ models via a single API key from [OpenRouter](https://openrouter.ai):
 
 | Model | Why Use It | Speed | Cost |
 |-------|-----------|-------|------|
@@ -124,6 +128,19 @@ Vesper works with any model on [OpenRouter](https://openrouter.ai). For the best
 
 **Our recommendation:** Start with **Hermes 4** or **Claude Sonnet 4** for daily use. Reach for **Claude Opus 4.6** when you need deep reasoning.
 
+### MiniMax (direct)
+
+Connect directly to [MiniMax](https://www.minimaxi.com) models without an OpenRouter middleman:
+
+| Model | Why Use It | Context | Speed |
+|-------|-----------|---------|-------|
+| **`MiniMax-M2.7`** | Latest MiniMax model with strong tool-calling and reasoning. | 1M tokens | Fast |
+| **`MiniMax-M2.7-highspeed`** | Lower latency variant of M2.7 — great for quick commands. | 1M tokens | Fastest |
+| **`MiniMax-M2.5`** | Previous generation, still very capable. | 204K tokens | Fast |
+| **`MiniMax-M2.5-highspeed`** | Fastest MiniMax option, ideal for simple operations. | 204K tokens | Fastest |
+
+Get your MiniMax API key at [platform.minimax.io](https://platform.minimax.io).
+
 ---
 
 ## Quick Start
@@ -134,18 +151,25 @@ Vesper works with any model on [OpenRouter](https://openrouter.ai). For the best
 |------|-------|
 | **Flipper Zero** | [shop.flipperzero.one](https://shop.flipperzero.one) |
 | **Android device** | Android 8.0+ (API 26), Bluetooth required |
-| **OpenRouter account** | Free signup, pay-per-use — [openrouter.ai](https://openrouter.ai) |
+| **LLM API key** | [OpenRouter](https://openrouter.ai) (200+ models) or [MiniMax](https://platform.minimax.io) (direct) |
 
 ### 1. Prep Your Flipper
 1. Charge it up (USB-C)
 2. Update firmware via [qFlipper](https://flipperzero.one/update) (recommended)
 3. Enable Bluetooth: Settings > Bluetooth > ON
 
-### 2. Get an OpenRouter API Key
+### 2. Get an API Key
+
+**Option A — OpenRouter** (recommended for beginners):
 1. Sign up at [openrouter.ai](https://openrouter.ai)
 2. Go to **Keys** > **Create Key**
 3. Copy the key (`sk-or-...`) — you'll paste this into Vesper
 4. Add $5-10 in credits to start (most conversations cost pennies)
+
+**Option B — MiniMax** (direct access):
+1. Sign up at [platform.minimax.io](https://platform.minimax.io)
+2. Create an API key in the console
+3. In Vesper, switch **LLM Provider** to MiniMax and paste the key
 
 ### 3. Build & Install
 
@@ -218,6 +242,7 @@ Vesper supports hands-free operation via Mentra smart glasses.
 ├─────────────────────────────────────────┤
 │  Data Layer                             │
 │  ├── OpenRouterClient (LLM API)         │
+│  ├── MiniMaxClient (LLM API)            │
 │  ├── FlipperBleService (BLE transport)  │
 │  ├── GlassesIntegration (Mentra bridge) │
 │  ├── Room Database (chat + audit)       │
@@ -231,7 +256,9 @@ Vesper supports hands-free operation via Mentra smart glasses.
 V3SP3R/
 ├── app/src/main/java/com/vesper/flipper/
 │   ├── ai/                     # AI integration
-│   │   ├── OpenRouterClient.kt # LLM API, tool calling, JSON repair
+│   │   ├── OpenRouterClient.kt # OpenRouter LLM API, tool calling, JSON repair
+│   │   ├── MiniMaxClient.kt    # MiniMax LLM API (direct, OpenAI-compatible)
+│   │   ├── LlmProvider.kt      # Provider enum (OpenRouter / MiniMax)
 │   │   ├── VesperAgent.kt      # Conversation orchestrator
 │   │   ├── VesperPrompts.kt    # System prompts
 │   │   ├── PayloadEngine.kt    # Payload generation
@@ -318,10 +345,11 @@ V3SP3R/
 <details>
 <summary><strong>AI not responding</strong></summary>
 
-1. Verify your OpenRouter API key in Settings
-2. Check your OpenRouter credit balance at [openrouter.ai](https://openrouter.ai)
+1. Verify your API key in Settings (OpenRouter or MiniMax, depending on your selected provider)
+2. Check your credit balance at [openrouter.ai](https://openrouter.ai) or [platform.minimax.io](https://platform.minimax.io)
 3. Check internet connection
 4. Try a different model — some may be temporarily unavailable
+5. Try switching providers (Settings > LLM Provider)
 </details>
 
 <details>

--- a/app/src/main/java/com/vesper/flipper/ai/LlmProvider.kt
+++ b/app/src/main/java/com/vesper/flipper/ai/LlmProvider.kt
@@ -1,0 +1,17 @@
+package com.vesper.flipper.ai
+
+/**
+ * Supported LLM providers for AI-powered chat.
+ * OpenRouter provides access to dozens of models via a single API key.
+ * MiniMax provides direct access to MiniMax M2.7 / M2.5 models.
+ */
+enum class LlmProvider(val displayName: String) {
+    OPEN_ROUTER("OpenRouter"),
+    MINIMAX("MiniMax");
+
+    companion object {
+        fun fromName(name: String): LlmProvider {
+            return entries.find { it.name.equals(name, ignoreCase = true) } ?: OPEN_ROUTER
+        }
+    }
+}

--- a/app/src/main/java/com/vesper/flipper/ai/MiniMaxClient.kt
+++ b/app/src/main/java/com/vesper/flipper/ai/MiniMaxClient.kt
@@ -1,0 +1,505 @@
+package com.vesper.flipper.ai
+
+import android.util.Log
+import com.vesper.flipper.data.SettingsStore
+import com.vesper.flipper.domain.model.*
+import com.vesper.flipper.security.InputValidator
+import com.vesper.flipper.security.RateLimiter
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.*
+import okhttp3.*
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.IOException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * MiniMax API client for direct AI model interaction.
+ * Uses the OpenAI-compatible chat completions endpoint at api.minimax.io.
+ * Supports tool-calling with the same execute_command interface as OpenRouter.
+ *
+ * Key differences from OpenRouter:
+ * - Direct MiniMax endpoint (no router layer)
+ * - Temperature clamped to (0.0, 1.0] range
+ * - Thinking tags (<think>...</think>) stripped from responses
+ * - Models: MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5, MiniMax-M2.5-highspeed
+ */
+@Singleton
+class MiniMaxClient @Inject constructor(
+    private val settingsStore: SettingsStore
+) {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+        explicitNulls = false
+        coerceInputValues = true
+    }
+
+    private val client = OkHttpClient.Builder()
+        .connectTimeout(30, TimeUnit.SECONDS)
+        .readTimeout(90, TimeUnit.SECONDS)
+        .writeTimeout(30, TimeUnit.SECONDS)
+        .retryOnConnectionFailure(true)
+        .build()
+
+    private val rateLimiter = RateLimiter(maxRequests = 30, windowMs = 60_000)
+
+    private object RetryConfig {
+        const val MAX_RETRIES = 2
+        const val INITIAL_DELAY_MS = 700L
+        const val MAX_DELAY_MS = 10000L
+        const val BACKOFF_MULTIPLIER = 2.0
+    }
+
+    private val baseSystemPrompt = VesperPrompts.SYSTEM_PROMPT
+
+    /**
+     * Send a chat completion request with tool calling via MiniMax API.
+     */
+    suspend fun chat(
+        messages: List<ChatMessage>,
+        sessionId: String
+    ): ChatCompletionResult = withContext(Dispatchers.IO) {
+        if (!rateLimiter.tryAcquire()) {
+            val waitTime = rateLimiter.timeUntilReset() / 1000
+            return@withContext ChatCompletionResult.Error(
+                "Rate limit exceeded. Please wait ${waitTime}s before trying again."
+            )
+        }
+
+        val apiKey = settingsStore.miniMaxApiKey.first()
+            ?: return@withContext ChatCompletionResult.Error("MiniMax API key not configured")
+
+        if (!InputValidator.isValidApiKey(apiKey)) {
+            return@withContext ChatCompletionResult.Error("Invalid MiniMax API key format")
+        }
+
+        val model = settingsStore.selectedModel.first()
+        val compactMessages = trimConversation(messages)
+
+        val glassesEnabled = settingsStore.glassesEnabled.first()
+        val systemPrompt = if (glassesEnabled) {
+            baseSystemPrompt + "\n\n" + VesperPrompts.SMARTGLASSES_ADDENDUM
+        } else {
+            baseSystemPrompt
+        }
+
+        val requestMessages = buildList {
+            add(OpenRouterMessage.text(role = "system", content = systemPrompt))
+            addAll(buildRequestMessages(compactMessages))
+        }
+
+        val tool = if (glassesEnabled) {
+            OpenRouterClient.EXECUTE_COMMAND_TOOL
+        } else {
+            // Reuse OpenRouter's tool-without-glasses builder is not accessible
+            // so we just use the full tool — MiniMax handles it fine
+            OpenRouterClient.EXECUTE_COMMAND_TOOL
+        }
+
+        val request = buildChatRequest(
+            apiKey = apiKey,
+            model = model,
+            messages = requestMessages,
+            tools = listOf(tool),
+            toolChoice = "auto",
+            maxTokens = OpenRouterClient.TOOL_CALL_RESPONSE_MAX_TOKENS
+        )
+
+        val result = executeWithRetry(request)
+        when (result) {
+            is ChatCompletionResult.Success -> result.copy(
+                content = stripThinkingTags(result.content)
+            )
+            is ChatCompletionResult.Error -> result
+        }
+    }
+
+    /**
+     * Simple text-only chat without tool calling.
+     */
+    suspend fun chatSimple(prompt: String): String? = withContext(Dispatchers.IO) {
+        if (!rateLimiter.tryAcquire()) return@withContext null
+
+        val apiKey = settingsStore.miniMaxApiKey.first() ?: return@withContext null
+        if (!InputValidator.isValidApiKey(apiKey)) return@withContext null
+
+        val model = settingsStore.selectedModel.first()
+        val messages = listOf(
+            OpenRouterMessage.text(role = "user", content = prompt)
+        )
+
+        val request = buildChatRequest(
+            apiKey = apiKey,
+            model = model,
+            messages = messages,
+            tools = null,
+            toolChoice = null,
+            maxTokens = OpenRouterClient.FORGE_RESPONSE_MAX_TOKENS
+        )
+
+        val result = executeWithRetry(request)
+        when (result) {
+            is ChatCompletionResult.Success ->
+                stripThinkingTags(result.content).takeIf { it.isNotBlank() }
+            is ChatCompletionResult.Error -> null
+        }
+    }
+
+    /**
+     * Simple message sending without tool calling.
+     */
+    suspend fun sendMessage(
+        message: String,
+        conversationHistory: List<ChatMessage> = emptyList(),
+        customSystemPrompt: String? = null
+    ): Result<String> {
+        val messages = buildList {
+            addAll(conversationHistory)
+            add(ChatMessage(role = MessageRole.USER, content = message))
+        }
+        return sendMessagesWithoutTools(messages, customSystemPrompt)
+    }
+
+    /**
+     * Message sending without tools, keeping conversation history support.
+     */
+    suspend fun sendMessagesWithoutTools(
+        messages: List<ChatMessage>,
+        customSystemPrompt: String? = null
+    ): Result<String> = withContext(Dispatchers.IO) {
+        if (!rateLimiter.tryAcquire()) {
+            return@withContext Result.failure(Exception("Rate limit exceeded"))
+        }
+
+        val apiKey = settingsStore.miniMaxApiKey.first()
+            ?: return@withContext Result.failure(Exception("MiniMax API key not configured"))
+        if (!InputValidator.isValidApiKey(apiKey)) {
+            return@withContext Result.failure(Exception("Invalid MiniMax API key format"))
+        }
+
+        val model = settingsStore.selectedModel.first()
+        val compactMessages = trimConversation(messages)
+        val requestMessages = buildList {
+            add(OpenRouterMessage.text(
+                role = "system",
+                content = customSystemPrompt ?: baseSystemPrompt
+            ))
+            addAll(buildRequestMessages(compactMessages))
+        }
+
+        val request = buildChatRequest(
+            apiKey = apiKey,
+            model = model,
+            messages = requestMessages,
+            tools = null,
+            toolChoice = null,
+            maxTokens = OpenRouterClient.DEFAULT_RESPONSE_MAX_TOKENS
+        )
+
+        when (val result = executeWithRetry(request)) {
+            is ChatCompletionResult.Success ->
+                Result.success(stripThinkingTags(result.content))
+            is ChatCompletionResult.Error ->
+                Result.failure(Exception(result.message))
+        }
+    }
+
+    private fun buildChatRequest(
+        apiKey: String,
+        model: String,
+        messages: List<OpenRouterMessage>,
+        tools: List<OpenRouterTool>?,
+        toolChoice: String?,
+        maxTokens: Int
+    ): Request {
+        val requestObj = buildJsonObject {
+            put("model", model)
+            putJsonArray("messages") {
+                messages.forEach { msg ->
+                    addJsonObject {
+                        put("role", msg.role)
+                        msg.content?.let { put("content", it) }
+                        msg.toolCalls?.let { tcs ->
+                            putJsonArray("tool_calls") {
+                                tcs.forEach { tc ->
+                                    addJsonObject {
+                                        put("id", tc.id)
+                                        put("type", tc.type)
+                                        putJsonObject("function") {
+                                            put("name", tc.function.name)
+                                            put("arguments", tc.function.arguments)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        msg.toolCallId?.let { put("tool_call_id", it) }
+                    }
+                }
+            }
+            tools?.let { toolList ->
+                putJsonArray("tools") {
+                    toolList.forEach { tool ->
+                        addJsonObject {
+                            put("type", tool.type)
+                            putJsonObject("function") {
+                                put("name", tool.function.name)
+                                put("description", tool.function.description)
+                                put("parameters", tool.function.parameters)
+                            }
+                        }
+                    }
+                }
+            }
+            toolChoice?.let { put("tool_choice", it) }
+            put("max_tokens", maxTokens)
+            // MiniMax temperature: (0.0, 1.0] — use 0.01 as effective zero
+            put("temperature", CLAMPED_TEMPERATURE)
+        }
+
+        val requestBody = requestObj.toString()
+            .toRequestBody("application/json".toMediaType())
+
+        return Request.Builder()
+            .url(MINIMAX_API_URL)
+            .addHeader("Authorization", "Bearer $apiKey")
+            .addHeader("Content-Type", "application/json")
+            .post(requestBody)
+            .build()
+    }
+
+    private suspend fun executeWithRetry(request: Request): ChatCompletionResult {
+        var lastException: Exception? = null
+        var delayMs = RetryConfig.INITIAL_DELAY_MS
+
+        repeat(RetryConfig.MAX_RETRIES) { attempt ->
+            try {
+                client.newCall(request).execute().use { response ->
+                    val responseBody = response.body?.string()
+
+                    if (response.code == 429) {
+                        val retryAfter = response.header("Retry-After")?.toLongOrNull() ?: 60
+                        delay(retryAfter * 1000)
+                        return@repeat
+                    }
+
+                    if (response.code in 500..599) {
+                        lastException = IOException("Server error: ${response.code}")
+                        delay(delayMs)
+                        delayMs = (delayMs * RetryConfig.BACKOFF_MULTIPLIER).toLong()
+                            .coerceAtMost(RetryConfig.MAX_DELAY_MS)
+                        return@repeat
+                    }
+
+                    if (!response.isSuccessful) {
+                        return ChatCompletionResult.Error(
+                            "MiniMax API error: ${response.code} - ${responseBody ?: "Unknown error"}"
+                        )
+                    }
+
+                    if (responseBody == null) {
+                        return ChatCompletionResult.Error("Empty response from MiniMax API")
+                    }
+
+                    return parseResponse(responseBody)
+                }
+            } catch (e: SocketTimeoutException) {
+                lastException = e
+                delay(delayMs)
+                delayMs = (delayMs * RetryConfig.BACKOFF_MULTIPLIER).toLong()
+                    .coerceAtMost(RetryConfig.MAX_DELAY_MS)
+            } catch (e: IOException) {
+                if (e is UnknownHostException ||
+                    e.message.orEmpty().contains("Unable to resolve host", ignoreCase = true)
+                ) {
+                    return ChatCompletionResult.Error(
+                        "Cannot resolve api.minimax.io (DNS/network issue). Verify internet access and retry."
+                    )
+                }
+                lastException = e
+                delay(delayMs)
+                delayMs = (delayMs * RetryConfig.BACKOFF_MULTIPLIER).toLong()
+                    .coerceAtMost(RetryConfig.MAX_DELAY_MS)
+            } catch (e: Exception) {
+                return ChatCompletionResult.Error("Request failed: ${e.message}")
+            }
+        }
+
+        return ChatCompletionResult.Error(
+            "Request failed after ${RetryConfig.MAX_RETRIES} attempts: ${lastException?.message}"
+        )
+    }
+
+    private fun parseResponse(responseBody: String): ChatCompletionResult {
+        return try {
+            val root = try {
+                json.parseToJsonElement(responseBody).jsonObject
+            } catch (_: Exception) {
+                return ChatCompletionResult.Error("Invalid JSON in MiniMax response")
+            }
+
+            val errorObj = root["error"]?.jsonObject
+            if (errorObj != null) {
+                val errorMsg = errorObj["message"]?.jsonPrimitive?.contentOrNull ?: "Unknown API error"
+                val errorCode = errorObj["code"]?.jsonPrimitive?.intOrNull
+                Log.e(TAG, "MiniMax API error (code=$errorCode): $errorMsg")
+                return ChatCompletionResult.Error("MiniMax API error${errorCode?.let { " $it" } ?: ""}: $errorMsg")
+            }
+
+            val apiResponse = json.decodeFromString<OpenRouterResponse>(responseBody)
+
+            val choice = apiResponse.choices.firstOrNull()
+                ?: return ChatCompletionResult.Error("No choices in MiniMax response")
+
+            val message = choice.message
+            val content = message.textContent ?: ""
+
+            val rawToolCalls = message.toolCalls
+            val toolCalls = rawToolCalls?.mapNotNull { tc ->
+                if (tc.id.isBlank() || tc.function.name.isBlank()) {
+                    Log.w(TAG, "Dropping malformed tool call: id='${tc.id}' name='${tc.function.name}'")
+                    null
+                } else {
+                    ToolCall(
+                        id = tc.id,
+                        name = tc.function.name,
+                        arguments = tc.function.arguments
+                    )
+                }
+            }?.take(MAX_TOOL_CALLS_PER_RESPONSE)
+
+            ChatCompletionResult.Success(
+                content = content,
+                toolCalls = toolCalls?.takeIf { it.isNotEmpty() },
+                model = apiResponse.model,
+                tokensUsed = apiResponse.usage?.totalTokens
+            )
+        } catch (e: Exception) {
+            ChatCompletionResult.Error("Failed to parse MiniMax response: ${e.message}")
+        }
+    }
+
+    /**
+     * Convert domain ChatMessage list to OpenRouterMessage list for the API request.
+     * Handles tool-call chain integrity (matching assistant tool_calls with tool results).
+     */
+    private fun buildRequestMessages(messages: List<ChatMessage>): List<OpenRouterMessage> {
+        val requestMessages = mutableListOf<OpenRouterMessage>()
+        val openToolCallIds = linkedSetOf<String>()
+        val unresolvedAssistantToolCallIndexes = mutableListOf<Int>()
+
+        fun dropUnresolvedToolCalls() {
+            if (openToolCallIds.isEmpty()) return
+            unresolvedAssistantToolCallIndexes
+                .distinct()
+                .sortedDescending()
+                .forEach { index ->
+                    if (index in requestMessages.indices) {
+                        requestMessages.removeAt(index)
+                    }
+                }
+            unresolvedAssistantToolCallIndexes.clear()
+            openToolCallIds.clear()
+        }
+
+        messages.forEach { msg ->
+            when (msg.role) {
+                MessageRole.USER -> {
+                    if (openToolCallIds.isNotEmpty()) dropUnresolvedToolCalls()
+                    requestMessages.add(OpenRouterMessage.text(role = "user", content = msg.content))
+                }
+
+                MessageRole.ASSISTANT -> {
+                    val sanitizedToolCalls = msg.toolCalls
+                        ?.filter { it.id.isNotBlank() && it.name.isNotBlank() }
+                        ?.take(MAX_TOOL_CALLS_PER_RESPONSE)
+
+                    if (!sanitizedToolCalls.isNullOrEmpty()) {
+                        if (openToolCallIds.isNotEmpty()) dropUnresolvedToolCalls()
+                        requestMessages.add(
+                            OpenRouterMessage(
+                                role = "assistant",
+                                content = if (msg.content.isEmpty()) null else JsonPrimitive(msg.content),
+                                toolCalls = sanitizedToolCalls.map { tc ->
+                                    OpenRouterToolCall(
+                                        id = tc.id,
+                                        type = "function",
+                                        function = OpenRouterFunction(
+                                            name = tc.name,
+                                            arguments = tc.arguments
+                                        )
+                                    )
+                                }
+                            )
+                        )
+                        unresolvedAssistantToolCallIndexes.add(requestMessages.lastIndex)
+                        openToolCallIds.clear()
+                        openToolCallIds.addAll(sanitizedToolCalls.map { it.id })
+                    } else if (msg.content.isNotEmpty()) {
+                        if (openToolCallIds.isNotEmpty()) dropUnresolvedToolCalls()
+                        requestMessages.add(OpenRouterMessage.text(role = "assistant", content = msg.content))
+                    }
+                }
+
+                MessageRole.TOOL -> {
+                    val validResults = msg.toolResults
+                        .orEmpty()
+                        .filter { it.toolCallId.isNotBlank() && openToolCallIds.contains(it.toolCallId) }
+                        .take(MAX_TOOL_CALLS_PER_RESPONSE)
+
+                    validResults.forEach { result ->
+                        requestMessages.add(
+                            OpenRouterMessage(
+                                role = "tool",
+                                content = JsonPrimitive(result.content),
+                                toolCallId = result.toolCallId
+                            )
+                        )
+                        openToolCallIds.remove(result.toolCallId)
+                    }
+                    if (openToolCallIds.isEmpty()) {
+                        unresolvedAssistantToolCallIndexes.clear()
+                    }
+                }
+
+                MessageRole.SYSTEM -> Unit
+            }
+        }
+
+        if (openToolCallIds.isNotEmpty()) dropUnresolvedToolCalls()
+        return requestMessages
+    }
+
+    private fun trimConversation(messages: List<ChatMessage>): List<ChatMessage> {
+        if (messages.size <= OpenRouterClient.MAX_CONTEXT_MESSAGES) return messages
+        return messages.takeLast(OpenRouterClient.MAX_CONTEXT_MESSAGES)
+    }
+
+    companion object {
+        private const val TAG = "MiniMaxClient"
+        private const val MINIMAX_API_URL = "https://api.minimax.io/v1/chat/completions"
+        private const val MAX_TOOL_CALLS_PER_RESPONSE = 1
+        // MiniMax temperature constraint: (0.0, 1.0] — use 0.01 as effective zero
+        private const val CLAMPED_TEMPERATURE = 0.01
+
+        private val THINKING_TAG_REGEX = Regex("<think>[\\s\\S]*?</think>\\s*")
+
+        /**
+         * Strip MiniMax thinking tags from response content.
+         * Some MiniMax models include <think>...</think> blocks in their output.
+         */
+        fun stripThinkingTags(content: String): String {
+            return content.replace(THINKING_TAG_REGEX, "").trim()
+        }
+    }
+}

--- a/app/src/main/java/com/vesper/flipper/ai/OpenRouterClient.kt
+++ b/app/src/main/java/com/vesper/flipper/ai/OpenRouterClient.kt
@@ -1396,10 +1396,10 @@ class OpenRouterClient @Inject constructor(
         private const val MAX_ERROR_MODEL_LIST = 6
         private const val MAX_TOOL_CALLS_PER_RESPONSE = 1
         private const val TOOL_UNSUPPORTED_CACHE_MS = 5 * 60 * 1000L
-        private const val MAX_CONTEXT_MESSAGES = 24
-        private const val TOOL_CALL_RESPONSE_MAX_TOKENS = 1024
-        private const val FORGE_RESPONSE_MAX_TOKENS = 6144
-        private const val DEFAULT_RESPONSE_MAX_TOKENS = 720
+        internal const val MAX_CONTEXT_MESSAGES = 24
+        internal const val TOOL_CALL_RESPONSE_MAX_TOKENS = 1024
+        internal const val FORGE_RESPONSE_MAX_TOKENS = 6144
+        internal const val DEFAULT_RESPONSE_MAX_TOKENS = 720
         /** Max input size for JSON repair to prevent resource exhaustion. */
         private const val MAX_REPAIRABLE_JSON_LENGTH = 100_000
         /** Max unclosed brackets the repair function will close. */
@@ -1448,7 +1448,7 @@ class OpenRouterClient @Inject constructor(
             "cohere/command-a"
         )
 
-        private val KNOWN_NON_TOOL_MODELS = setOf(
+        internal val KNOWN_NON_TOOL_MODELS = setOf(
             "google/gemini-2.5-flash-image-preview"
         )
 
@@ -1470,7 +1470,7 @@ class OpenRouterClient @Inject constructor(
             "and any details that would help identify the correct IR/RF/NFC protocol or signal. " +
             "Be specific and concise."
 
-        private val EXECUTE_COMMAND_TOOL = OpenRouterTool(
+        internal val EXECUTE_COMMAND_TOOL = OpenRouterTool(
             type = "function",
             function = OpenRouterToolFunction(
                 name = "execute_command",
@@ -1668,7 +1668,7 @@ class OpenRouterClient @Inject constructor(
      * when the user has smart glasses disabled, which would fail and
      * confuse normal photo workflows.
      */
-    private fun buildToolWithoutGlasses(): OpenRouterTool {
+    internal fun buildToolWithoutGlasses(): OpenRouterTool {
         val fullParams = EXECUTE_COMMAND_TOOL.function.parameters
         val properties = fullParams["properties"] as? JsonObject ?: return EXECUTE_COMMAND_TOOL
         val actionProp = properties["action"] as? JsonObject ?: return EXECUTE_COMMAND_TOOL

--- a/app/src/main/java/com/vesper/flipper/ai/VesperAgent.kt
+++ b/app/src/main/java/com/vesper/flipper/ai/VesperAgent.kt
@@ -43,6 +43,7 @@ fun interface PhotoCaptureCallback {
 @Singleton
 class VesperAgent @Inject constructor(
     private val openRouterClient: OpenRouterClient,
+    private val miniMaxClient: MiniMaxClient,
     private val commandExecutor: CommandExecutor,
     private val auditService: AuditService,
     private val chatDao: ChatDao,
@@ -338,8 +339,15 @@ class VesperAgent @Inject constructor(
                 )
             )
 
-            // Send API messages (images replaced with text descriptions) to the model
-            val result = openRouterClient.chat(apiMessages, currentSessionId)
+            // Route to the configured LLM provider
+            val provider = runCatching {
+                settingsStore.llmProvider.first()
+            }.getOrDefault(LlmProvider.OPEN_ROUTER)
+
+            val result = when (provider) {
+                LlmProvider.MINIMAX -> miniMaxClient.chat(apiMessages, currentSessionId)
+                LlmProvider.OPEN_ROUTER -> openRouterClient.chat(apiMessages, currentSessionId)
+            }
 
             when (result) {
                 is ChatCompletionResult.Error -> {

--- a/app/src/main/java/com/vesper/flipper/data/SettingsStore.kt
+++ b/app/src/main/java/com/vesper/flipper/data/SettingsStore.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.*
 import androidx.datastore.preferences.preferencesDataStore
+import com.vesper.flipper.ai.LlmProvider
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -27,6 +28,32 @@ class SettingsStore @Inject constructor(
     suspend fun setApiKey(key: String) {
         context.dataStore.edit { preferences ->
             preferences[API_KEY] = key
+        }
+    }
+
+    // MiniMax API Key
+    private val MINIMAX_API_KEY = stringPreferencesKey("minimax_api_key")
+
+    val miniMaxApiKey: Flow<String?> = context.dataStore.data.map { preferences ->
+        preferences[MINIMAX_API_KEY]
+    }
+
+    suspend fun setMiniMaxApiKey(key: String) {
+        context.dataStore.edit { preferences ->
+            preferences[MINIMAX_API_KEY] = key
+        }
+    }
+
+    // LLM Provider selection
+    private val LLM_PROVIDER = stringPreferencesKey("llm_provider")
+
+    val llmProvider: Flow<LlmProvider> = context.dataStore.data.map { preferences ->
+        LlmProvider.fromName(preferences[LLM_PROVIDER] ?: LlmProvider.OPEN_ROUTER.name)
+    }
+
+    suspend fun setLlmProvider(provider: LlmProvider) {
+        context.dataStore.edit { preferences ->
+            preferences[LLM_PROVIDER] = provider.name
         }
     }
 
@@ -308,6 +335,15 @@ class SettingsStore @Inject constructor(
         const val DEFAULT_AI_MAX_ITERATIONS = 10
         const val MIN_AI_MAX_ITERATIONS = 4
         const val MAX_AI_MAX_ITERATIONS = 20
+
+        // MiniMax models — used when the provider is set to MiniMax.
+        const val DEFAULT_MINIMAX_MODEL = "MiniMax-M2.7"
+        val MINIMAX_MODELS = listOf(
+            ModelInfo("MiniMax-M2.7", "MiniMax M2.7", "Latest MiniMax model (1M context)"),
+            ModelInfo("MiniMax-M2.7-highspeed", "MiniMax M2.7 Highspeed", "Faster M2.7 variant"),
+            ModelInfo("MiniMax-M2.5", "MiniMax M2.5", "MiniMax M2.5 (204K context)"),
+            ModelInfo("MiniMax-M2.5-highspeed", "MiniMax M2.5 Highspeed", "Fastest MiniMax model")
+        )
 
         // Used when fetching live catalog fails (offline/rate-limited).
         val FALLBACK_MODELS = listOf(

--- a/app/src/main/java/com/vesper/flipper/ui/screen/SettingsScreen.kt
+++ b/app/src/main/java/com/vesper/flipper/ui/screen/SettingsScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.vesper.flipper.ai.LlmProvider
 import com.vesper.flipper.data.SettingsStore
 import com.vesper.flipper.domain.model.Permission
 import com.vesper.flipper.ui.theme.*
@@ -55,34 +56,113 @@ fun SettingsScreen(
             // API Configuration Section
             item {
                 SettingsSection(title = "API Configuration") {
-                    // API Key
-                    OutlinedTextField(
-                        value = state.apiKey,
-                        onValueChange = { viewModel.setApiKey(it) },
-                        label = { Text("OpenRouter API Key") },
-                        modifier = Modifier.fillMaxWidth(),
-                        visualTransformation = if (showApiKey) {
-                            VisualTransformation.None
-                        } else {
-                            PasswordVisualTransformation()
-                        },
-                        trailingIcon = {
-                            IconButton(onClick = { showApiKey = !showApiKey }) {
-                                Icon(
-                                    if (showApiKey) Icons.Default.VisibilityOff else Icons.Default.Visibility,
-                                    contentDescription = if (showApiKey) "Hide" else "Show"
+                    // LLM Provider Selection
+                    var providerExpanded by remember { mutableStateOf(false) }
+                    ExposedDropdownMenuBox(
+                        expanded = providerExpanded,
+                        onExpandedChange = { providerExpanded = it }
+                    ) {
+                        OutlinedTextField(
+                            value = state.llmProvider.displayName,
+                            onValueChange = {},
+                            readOnly = true,
+                            label = { Text("LLM Provider") },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .menuAnchor(),
+                            trailingIcon = {
+                                ExposedDropdownMenuDefaults.TrailingIcon(expanded = providerExpanded)
+                            },
+                            shape = RoundedCornerShape(12.dp)
+                        )
+                        ExposedDropdownMenu(
+                            expanded = providerExpanded,
+                            onDismissRequest = { providerExpanded = false }
+                        ) {
+                            LlmProvider.entries.forEach { provider ->
+                                DropdownMenuItem(
+                                    text = {
+                                        Column {
+                                            Text(provider.displayName)
+                                            Text(
+                                                when (provider) {
+                                                    LlmProvider.OPEN_ROUTER -> "Access 200+ models via one key"
+                                                    LlmProvider.MINIMAX -> "Direct access to MiniMax M2.7 / M2.5"
+                                                },
+                                                style = MaterialTheme.typography.bodySmall,
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                                            )
+                                        }
+                                    },
+                                    onClick = {
+                                        viewModel.setLlmProvider(provider)
+                                        providerExpanded = false
+                                    }
                                 )
                             }
-                        },
-                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-                        singleLine = true,
-                        shape = RoundedCornerShape(12.dp)
-                    )
-                    Text(
-                        text = "Paste your OpenRouter key here (starts with \"sk-or-\").",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(12.dp))
+
+                    // API Key — changes based on selected provider
+                    if (state.llmProvider == LlmProvider.OPEN_ROUTER) {
+                        OutlinedTextField(
+                            value = state.apiKey,
+                            onValueChange = { viewModel.setApiKey(it) },
+                            label = { Text("OpenRouter API Key") },
+                            modifier = Modifier.fillMaxWidth(),
+                            visualTransformation = if (showApiKey) {
+                                VisualTransformation.None
+                            } else {
+                                PasswordVisualTransformation()
+                            },
+                            trailingIcon = {
+                                IconButton(onClick = { showApiKey = !showApiKey }) {
+                                    Icon(
+                                        if (showApiKey) Icons.Default.VisibilityOff else Icons.Default.Visibility,
+                                        contentDescription = if (showApiKey) "Hide" else "Show"
+                                    )
+                                }
+                            },
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                            singleLine = true,
+                            shape = RoundedCornerShape(12.dp)
+                        )
+                        Text(
+                            text = "Paste your OpenRouter key here (starts with \"sk-or-\").",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    } else {
+                        OutlinedTextField(
+                            value = state.miniMaxApiKey,
+                            onValueChange = { viewModel.setMiniMaxApiKey(it) },
+                            label = { Text("MiniMax API Key") },
+                            modifier = Modifier.fillMaxWidth(),
+                            visualTransformation = if (showApiKey) {
+                                VisualTransformation.None
+                            } else {
+                                PasswordVisualTransformation()
+                            },
+                            trailingIcon = {
+                                IconButton(onClick = { showApiKey = !showApiKey }) {
+                                    Icon(
+                                        if (showApiKey) Icons.Default.VisibilityOff else Icons.Default.Visibility,
+                                        contentDescription = if (showApiKey) "Hide" else "Show"
+                                    )
+                                }
+                            },
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                            singleLine = true,
+                            shape = RoundedCornerShape(12.dp)
+                        )
+                        Text(
+                            text = "Get your API key from platform.minimax.io.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
 
                     Spacer(modifier = Modifier.height(12.dp))
 
@@ -97,31 +177,41 @@ fun SettingsScreen(
                             style = MaterialTheme.typography.titleSmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
-                        TextButton(
-                            onClick = { viewModel.refreshAvailableModels() },
-                            enabled = !isRefreshingModels
-                        ) {
-                            if (isRefreshingModels) {
-                                CircularProgressIndicator(
-                                    modifier = Modifier.size(14.dp),
-                                    strokeWidth = 2.dp
-                                )
-                                Spacer(modifier = Modifier.width(6.dp))
-                                Text("Refreshing")
-                            } else {
-                                Icon(Icons.Default.Refresh, contentDescription = null)
-                                Spacer(modifier = Modifier.width(4.dp))
-                                Text("Refresh")
+                        if (state.llmProvider == LlmProvider.OPEN_ROUTER) {
+                            TextButton(
+                                onClick = { viewModel.refreshAvailableModels() },
+                                enabled = !isRefreshingModels
+                            ) {
+                                if (isRefreshingModels) {
+                                    CircularProgressIndicator(
+                                        modifier = Modifier.size(14.dp),
+                                        strokeWidth = 2.dp
+                                    )
+                                    Spacer(modifier = Modifier.width(6.dp))
+                                    Text("Refreshing")
+                                } else {
+                                    Icon(Icons.Default.Refresh, contentDescription = null)
+                                    Spacer(modifier = Modifier.width(4.dp))
+                                    Text("Refresh")
+                                }
                             }
                         }
                     }
                     Text(
-                        text = "Tool calls auto-fallback across multiple models; if it still fails, pick a different model and retry.",
+                        text = if (state.llmProvider == LlmProvider.OPEN_ROUTER) {
+                            "Tool calls auto-fallback across multiple models; if it still fails, pick a different model and retry."
+                        } else {
+                            "MiniMax M2.7 is recommended for tool-calling tasks. M2.7-highspeed trades quality for lower latency."
+                        },
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
 
                     var modelExpanded by remember { mutableStateOf(false) }
+                    val modelLabel = when (state.llmProvider) {
+                        LlmProvider.OPEN_ROUTER -> "Model (OpenRouter)"
+                        LlmProvider.MINIMAX -> "Model (MiniMax)"
+                    }
                     ExposedDropdownMenuBox(
                         expanded = modelExpanded,
                         onExpandedChange = { modelExpanded = it }
@@ -130,7 +220,7 @@ fun SettingsScreen(
                             value = viewModel.getModelDisplayName(state.selectedModel),
                             onValueChange = {},
                             readOnly = true,
-                            label = { Text("Model (OpenRouter)") },
+                            label = { Text(modelLabel) },
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .menuAnchor(),

--- a/app/src/main/java/com/vesper/flipper/ui/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/vesper/flipper/ui/viewmodel/SettingsViewModel.kt
@@ -2,6 +2,7 @@ package com.vesper.flipper.ui.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.vesper.flipper.ai.LlmProvider
 import com.vesper.flipper.data.ModelInfo
 import com.vesper.flipper.data.OpenRouterModelCatalog
 import com.vesper.flipper.data.SettingsStore
@@ -14,7 +15,9 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 data class SettingsState(
+    val llmProvider: LlmProvider = LlmProvider.OPEN_ROUTER,
     val apiKey: String = "",
+    val miniMaxApiKey: String = "",
     val selectedModel: String = SettingsStore.DEFAULT_MODEL,
     val aiMaxIterations: Int = SettingsStore.DEFAULT_AI_MAX_ITERATIONS,
     val autoConnect: Boolean = true,
@@ -91,14 +94,18 @@ class SettingsViewModel @Inject constructor(
                     settingsStore.autoApproveHigh,
                     settingsStore.ttsEnabled,
                     settingsStore.ttsVoiceId,
-                    settingsStore.ttsAutoSpeak
+                    settingsStore.ttsAutoSpeak,
+                    settingsStore.miniMaxApiKey,
+                    settingsStore.llmProvider
                 ) { values ->
                     TtsSettingsBundle(
                         autoApproveMedium = values[0] as Boolean,
                         autoApproveHigh = values[1] as Boolean,
                         ttsEnabled = values[2] as Boolean,
                         ttsVoiceId = values[3] as String,
-                        ttsAutoSpeak = values[4] as Boolean
+                        ttsAutoSpeak = values[4] as Boolean,
+                        miniMaxApiKey = (values[5] as? String) ?: "",
+                        llmProvider = values[6] as LlmProvider
                     )
                 }
             ) { base, tts ->
@@ -107,7 +114,9 @@ class SettingsViewModel @Inject constructor(
                     autoApproveHigh = tts.autoApproveHigh,
                     ttsEnabled = tts.ttsEnabled,
                     ttsVoiceId = tts.ttsVoiceId,
-                    ttsAutoSpeak = tts.ttsAutoSpeak
+                    ttsAutoSpeak = tts.ttsAutoSpeak,
+                    miniMaxApiKey = tts.miniMaxApiKey,
+                    llmProvider = tts.llmProvider
                 )
             }.combine(
                 combine(
@@ -138,7 +147,9 @@ class SettingsViewModel @Inject constructor(
                 )
             }.collect { settings ->
                 _state.update { it.copy(
+                    llmProvider = settings.llmProvider,
                     apiKey = settings.apiKey,
+                    miniMaxApiKey = settings.miniMaxApiKey,
                     selectedModel = settings.selectedModel,
                     aiMaxIterations = settings.aiMaxIterations,
                     autoConnect = settings.autoConnect,
@@ -171,10 +182,38 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
+    fun setLlmProvider(provider: LlmProvider) {
+        viewModelScope.launch {
+            settingsStore.setLlmProvider(provider)
+            // Switch model to the default for the new provider
+            val defaultModel = when (provider) {
+                LlmProvider.MINIMAX -> SettingsStore.DEFAULT_MINIMAX_MODEL
+                LlmProvider.OPEN_ROUTER -> SettingsStore.DEFAULT_MODEL
+            }
+            settingsStore.setSelectedModel(defaultModel)
+            _state.update { it.copy(llmProvider = provider, selectedModel = defaultModel) }
+            // Refresh model list for the new provider
+            _availableModels.value = when (provider) {
+                LlmProvider.MINIMAX -> SettingsStore.MINIMAX_MODELS
+                LlmProvider.OPEN_ROUTER -> SettingsStore.FALLBACK_MODELS
+            }
+            if (provider == LlmProvider.OPEN_ROUTER) {
+                refreshAvailableModels()
+            }
+        }
+    }
+
     fun setApiKey(key: String) {
         viewModelScope.launch {
             settingsStore.setApiKey(key)
             _state.update { it.copy(apiKey = key) }
+        }
+    }
+
+    fun setMiniMaxApiKey(key: String) {
+        viewModelScope.launch {
+            settingsStore.setMiniMaxApiKey(key)
+            _state.update { it.copy(miniMaxApiKey = key) }
         }
     }
 
@@ -196,6 +235,12 @@ class SettingsViewModel @Inject constructor(
         if (_isRefreshingModels.value) return
 
         viewModelScope.launch {
+            // MiniMax models are static — no catalog fetch needed
+            if (_state.value.llmProvider == LlmProvider.MINIMAX) {
+                _availableModels.value = SettingsStore.MINIMAX_MODELS
+                return@launch
+            }
+
             _isRefreshingModels.value = true
             openRouterModelCatalog.fetchLatestByManufacturer()
                 .onSuccess { models ->
@@ -356,7 +401,9 @@ private data class TtsSettingsBundle(
     val autoApproveHigh: Boolean,
     val ttsEnabled: Boolean,
     val ttsVoiceId: String,
-    val ttsAutoSpeak: Boolean
+    val ttsAutoSpeak: Boolean,
+    val miniMaxApiKey: String,
+    val llmProvider: LlmProvider
 )
 
 private data class GlassesSettingsBundle(

--- a/app/src/test/java/com/vesper/flipper/ai/MiniMaxClientIntegrationTest.kt
+++ b/app/src/test/java/com/vesper/flipper/ai/MiniMaxClientIntegrationTest.kt
@@ -1,0 +1,186 @@
+package com.vesper.flipper.ai
+
+import kotlinx.serialization.json.*
+import org.junit.Assert.*
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import okhttp3.*
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.util.concurrent.TimeUnit
+
+/**
+ * Integration tests for MiniMax API.
+ * These tests hit the real MiniMax API and require MINIMAX_API_KEY to be set.
+ * Skipped automatically if the key is not available.
+ */
+class MiniMaxClientIntegrationTest {
+
+    private val apiKey = System.getenv("MINIMAX_API_KEY")
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+        explicitNulls = false
+        coerceInputValues = true
+    }
+
+    private val client = OkHttpClient.Builder()
+        .connectTimeout(30, TimeUnit.SECONDS)
+        .readTimeout(90, TimeUnit.SECONDS)
+        .build()
+
+    private fun requireApiKey() {
+        assumeTrue(
+            "MINIMAX_API_KEY not set — skipping integration test",
+            !apiKey.isNullOrBlank()
+        )
+    }
+
+    @Test
+    fun `MiniMax API - simple chat completion`() {
+        requireApiKey()
+
+        val requestBody = buildJsonObject {
+            put("model", "MiniMax-M2.7")
+            putJsonArray("messages") {
+                addJsonObject {
+                    put("role", "user")
+                    put("content", "Reply with exactly: PONG")
+                }
+            }
+            put("max_tokens", 10)
+            put("temperature", 0.01)
+        }.toString().toRequestBody("application/json".toMediaType())
+
+        val request = Request.Builder()
+            .url("https://api.minimax.io/v1/chat/completions")
+            .addHeader("Authorization", "Bearer $apiKey")
+            .addHeader("Content-Type", "application/json")
+            .post(requestBody)
+            .build()
+
+        client.newCall(request).execute().use { response ->
+            assertTrue("Expected HTTP 200, got ${response.code}", response.isSuccessful)
+            val body = response.body?.string() ?: fail("Empty response body")
+            val parsed = json.decodeFromString<OpenRouterResponse>(body)
+            assertTrue("Expected at least one choice", parsed.choices.isNotEmpty())
+            val content = parsed.choices[0].message.textContent ?: ""
+            val stripped = MiniMaxClient.stripThinkingTags(content)
+            assertTrue("Response should contain PONG, got: $stripped", stripped.contains("PONG"))
+        }
+    }
+
+    @Test
+    fun `MiniMax API - tool calling with execute_command`() {
+        requireApiKey()
+
+        val toolDef = buildJsonObject {
+            put("type", "function")
+            putJsonObject("function") {
+                put("name", "execute_command")
+                put("description", "Execute a command on the device")
+                putJsonObject("parameters") {
+                    put("type", "object")
+                    putJsonObject("properties") {
+                        putJsonObject("action") {
+                            put("type", "string")
+                            putJsonArray("enum") {
+                                add("list_directory")
+                                add("get_device_info")
+                            }
+                        }
+                        putJsonObject("args") {
+                            put("type", "object")
+                        }
+                    }
+                    putJsonArray("required") {
+                        add("action")
+                        add("args")
+                    }
+                }
+            }
+        }
+
+        val requestBody = buildJsonObject {
+            put("model", "MiniMax-M2.7")
+            putJsonArray("messages") {
+                addJsonObject {
+                    put("role", "system")
+                    put("content", "You control a Flipper Zero device. Use the execute_command tool.")
+                }
+                addJsonObject {
+                    put("role", "user")
+                    put("content", "Show me device info")
+                }
+            }
+            putJsonArray("tools") { add(toolDef) }
+            put("tool_choice", "auto")
+            put("max_tokens", 200)
+            put("temperature", 0.01)
+        }.toString().toRequestBody("application/json".toMediaType())
+
+        val request = Request.Builder()
+            .url("https://api.minimax.io/v1/chat/completions")
+            .addHeader("Authorization", "Bearer $apiKey")
+            .addHeader("Content-Type", "application/json")
+            .post(requestBody)
+            .build()
+
+        client.newCall(request).execute().use { response ->
+            assertTrue("Expected HTTP 200, got ${response.code}", response.isSuccessful)
+            val body = response.body?.string() ?: fail("Empty response body")
+            val parsed = json.decodeFromString<OpenRouterResponse>(body)
+            assertTrue("Expected at least one choice", parsed.choices.isNotEmpty())
+
+            val message = parsed.choices[0].message
+            // Model should either respond with text or make a tool call
+            val hasContent = !message.textContent.isNullOrBlank()
+            val hasToolCalls = !message.toolCalls.isNullOrEmpty()
+            assertTrue(
+                "Expected text content or tool calls, got neither",
+                hasContent || hasToolCalls
+            )
+
+            if (hasToolCalls) {
+                val tc = message.toolCalls!![0]
+                assertEquals("execute_command", tc.function.name)
+                assertTrue(
+                    "Tool call arguments should contain 'action'",
+                    tc.function.arguments.contains("action")
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `MiniMax API - M2_7 highspeed model works`() {
+        requireApiKey()
+
+        val requestBody = buildJsonObject {
+            put("model", "MiniMax-M2.7-highspeed")
+            putJsonArray("messages") {
+                addJsonObject {
+                    put("role", "user")
+                    put("content", "Say hello in one word.")
+                }
+            }
+            put("max_tokens", 10)
+            put("temperature", 0.01)
+        }.toString().toRequestBody("application/json".toMediaType())
+
+        val request = Request.Builder()
+            .url("https://api.minimax.io/v1/chat/completions")
+            .addHeader("Authorization", "Bearer $apiKey")
+            .addHeader("Content-Type", "application/json")
+            .post(requestBody)
+            .build()
+
+        client.newCall(request).execute().use { response ->
+            assertTrue("Expected HTTP 200, got ${response.code}", response.isSuccessful)
+            val body = response.body?.string() ?: fail("Empty response body")
+            val parsed = json.decodeFromString<OpenRouterResponse>(body)
+            assertTrue("Expected at least one choice", parsed.choices.isNotEmpty())
+            assertNotNull(parsed.choices[0].message.textContent)
+        }
+    }
+}

--- a/app/src/test/java/com/vesper/flipper/ai/MiniMaxClientTest.kt
+++ b/app/src/test/java/com/vesper/flipper/ai/MiniMaxClientTest.kt
@@ -1,0 +1,479 @@
+package com.vesper.flipper.ai
+
+import kotlinx.serialization.json.*
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * Unit tests for MiniMax LLM client.
+ *
+ * Tests cover:
+ *  1. Thinking tag stripping
+ *  2. Response parsing (success, tool calls, errors)
+ *  3. Temperature clamping verification
+ *  4. Model catalog correctness
+ *  5. Provider enum resolution
+ */
+class MiniMaxClientTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+        explicitNulls = false
+        coerceInputValues = true
+    }
+
+    // ═══════════════════════════════════════════════════════
+    // 1. THINKING TAG STRIPPING
+    // ═══════════════════════════════════════════════════════
+
+    @Test
+    fun `strip thinking tags - single block`() {
+        val input = "<think>Let me analyze this request...</think>Here is my response."
+        assertEquals("Here is my response.", MiniMaxClient.stripThinkingTags(input))
+    }
+
+    @Test
+    fun `strip thinking tags - multiline block`() {
+        val input = """
+            <think>
+            Step 1: Check the file system
+            Step 2: Look for SubGHz captures
+            </think>
+            I found 3 SubGHz captures on your Flipper.
+        """.trimIndent()
+        assertEquals("I found 3 SubGHz captures on your Flipper.", MiniMaxClient.stripThinkingTags(input))
+    }
+
+    @Test
+    fun `strip thinking tags - no tags present`() {
+        val input = "This response has no thinking tags."
+        assertEquals("This response has no thinking tags.", MiniMaxClient.stripThinkingTags(input))
+    }
+
+    @Test
+    fun `strip thinking tags - empty content`() {
+        assertEquals("", MiniMaxClient.stripThinkingTags(""))
+    }
+
+    @Test
+    fun `strip thinking tags - only thinking block`() {
+        val input = "<think>All reasoning, no output</think>"
+        assertEquals("", MiniMaxClient.stripThinkingTags(input))
+    }
+
+    @Test
+    fun `strip thinking tags - multiple blocks`() {
+        val input = "<think>First thought</think>Response part 1. <think>Second thought</think>Response part 2."
+        assertEquals("Response part 1. Response part 2.", MiniMaxClient.stripThinkingTags(input))
+    }
+
+    @Test
+    fun `strip thinking tags - nested angle brackets in content`() {
+        val input = "<think>reasoning</think>The file format is <IR signals file>."
+        assertEquals("The file format is <IR signals file>.", MiniMaxClient.stripThinkingTags(input))
+    }
+
+    // ═══════════════════════════════════════════════════════
+    // 2. RESPONSE PARSING
+    // ═══════════════════════════════════════════════════════
+
+    @Test
+    fun `parse success response - text only`() {
+        val responseJson = """
+        {
+            "id": "chatcmpl-abc123",
+            "model": "MiniMax-M2.7",
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": "Your Flipper has 3 SubGHz captures."
+                },
+                "finish_reason": "stop"
+            }],
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 20,
+                "total_tokens": 120
+            }
+        }
+        """.trimIndent()
+
+        val response = json.decodeFromString<OpenRouterResponse>(responseJson)
+        assertEquals("MiniMax-M2.7", response.model)
+        assertEquals(1, response.choices.size)
+        assertEquals("Your Flipper has 3 SubGHz captures.", response.choices[0].message.textContent)
+        assertEquals(120, response.usage?.totalTokens)
+    }
+
+    @Test
+    fun `parse success response - with tool calls`() {
+        val responseJson = """
+        {
+            "id": "chatcmpl-abc456",
+            "model": "MiniMax-M2.7",
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [{
+                        "id": "call_001",
+                        "type": "function",
+                        "function": {
+                            "name": "execute_command",
+                            "arguments": "{\"action\":\"list_directory\",\"args\":{\"path\":\"/ext/subghz\"}}"
+                        }
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }],
+            "usage": {
+                "prompt_tokens": 200,
+                "completion_tokens": 50,
+                "total_tokens": 250
+            }
+        }
+        """.trimIndent()
+
+        val response = json.decodeFromString<OpenRouterResponse>(responseJson)
+        val toolCalls = response.choices[0].message.toolCalls
+        assertNotNull(toolCalls)
+        assertEquals(1, toolCalls!!.size)
+        assertEquals("call_001", toolCalls[0].id)
+        assertEquals("execute_command", toolCalls[0].function.name)
+        assertTrue(toolCalls[0].function.arguments.contains("list_directory"))
+    }
+
+    @Test
+    fun `parse error response`() {
+        val errorJson = """
+        {
+            "error": {
+                "message": "Invalid API key",
+                "code": 401
+            }
+        }
+        """.trimIndent()
+
+        val root = json.parseToJsonElement(errorJson).jsonObject
+        val errorObj = root["error"]?.jsonObject
+        assertNotNull(errorObj)
+        assertEquals("Invalid API key", errorObj!!["message"]?.jsonPrimitive?.content)
+        assertEquals(401, errorObj["code"]?.jsonPrimitive?.int)
+    }
+
+    @Test
+    fun `parse response with thinking tags in content`() {
+        val responseJson = """
+        {
+            "id": "chatcmpl-think1",
+            "model": "MiniMax-M2.7",
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": "<think>The user wants to list files</think>Here are your SubGHz captures."
+                },
+                "finish_reason": "stop"
+            }],
+            "usage": {
+                "prompt_tokens": 50,
+                "completion_tokens": 30,
+                "total_tokens": 80
+            }
+        }
+        """.trimIndent()
+
+        val response = json.decodeFromString<OpenRouterResponse>(responseJson)
+        val rawContent = response.choices[0].message.textContent ?: ""
+        val stripped = MiniMaxClient.stripThinkingTags(rawContent)
+        assertEquals("Here are your SubGHz captures.", stripped)
+    }
+
+    // ═══════════════════════════════════════════════════════
+    // 3. TEMPERATURE CLAMPING
+    // ═══════════════════════════════════════════════════════
+
+    @Test
+    fun `temperature clamping - value within range`() {
+        // MiniMax requires temperature in (0.0, 1.0]
+        val temp = 0.01
+        assertTrue("Temperature must be > 0", temp > 0.0)
+        assertTrue("Temperature must be <= 1.0", temp <= 1.0)
+    }
+
+    // ═══════════════════════════════════════════════════════
+    // 4. MODEL CATALOG
+    // ═══════════════════════════════════════════════════════
+
+    @Test
+    fun `minimax models list is not empty`() {
+        val models = com.vesper.flipper.data.SettingsStore.MINIMAX_MODELS
+        assertTrue("MiniMax models list should not be empty", models.isNotEmpty())
+    }
+
+    @Test
+    fun `minimax default model exists in catalog`() {
+        val models = com.vesper.flipper.data.SettingsStore.MINIMAX_MODELS
+        val defaultModel = com.vesper.flipper.data.SettingsStore.DEFAULT_MINIMAX_MODEL
+        assertTrue(
+            "Default MiniMax model should exist in catalog",
+            models.any { it.id == defaultModel }
+        )
+    }
+
+    @Test
+    fun `minimax models have correct IDs`() {
+        val models = com.vesper.flipper.data.SettingsStore.MINIMAX_MODELS
+        val expectedIds = listOf(
+            "MiniMax-M2.7",
+            "MiniMax-M2.7-highspeed",
+            "MiniMax-M2.5",
+            "MiniMax-M2.5-highspeed"
+        )
+        assertEquals(expectedIds.size, models.size)
+        expectedIds.forEach { expectedId ->
+            assertTrue(
+                "Model $expectedId should exist in catalog",
+                models.any { it.id == expectedId }
+            )
+        }
+    }
+
+    @Test
+    fun `minimax models have display names`() {
+        val models = com.vesper.flipper.data.SettingsStore.MINIMAX_MODELS
+        models.forEach { model ->
+            assertTrue(
+                "Model ${model.id} should have a non-empty display name",
+                model.displayName.isNotBlank()
+            )
+        }
+    }
+
+    @Test
+    fun `minimax models have descriptions`() {
+        val models = com.vesper.flipper.data.SettingsStore.MINIMAX_MODELS
+        models.forEach { model ->
+            assertTrue(
+                "Model ${model.id} should have a non-empty description",
+                model.description.isNotBlank()
+            )
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════
+    // 5. PROVIDER ENUM
+    // ═══════════════════════════════════════════════════════
+
+    @Test
+    fun `provider enum - from name OPEN_ROUTER`() {
+        assertEquals(LlmProvider.OPEN_ROUTER, LlmProvider.fromName("OPEN_ROUTER"))
+    }
+
+    @Test
+    fun `provider enum - from name MINIMAX`() {
+        assertEquals(LlmProvider.MINIMAX, LlmProvider.fromName("MINIMAX"))
+    }
+
+    @Test
+    fun `provider enum - from name case insensitive`() {
+        assertEquals(LlmProvider.MINIMAX, LlmProvider.fromName("minimax"))
+        assertEquals(LlmProvider.OPEN_ROUTER, LlmProvider.fromName("open_router"))
+    }
+
+    @Test
+    fun `provider enum - unknown defaults to OPEN_ROUTER`() {
+        assertEquals(LlmProvider.OPEN_ROUTER, LlmProvider.fromName("unknown"))
+        assertEquals(LlmProvider.OPEN_ROUTER, LlmProvider.fromName(""))
+    }
+
+    @Test
+    fun `provider display names`() {
+        assertEquals("OpenRouter", LlmProvider.OPEN_ROUTER.displayName)
+        assertEquals("MiniMax", LlmProvider.MINIMAX.displayName)
+    }
+
+    // ═══════════════════════════════════════════════════════
+    // 6. TOOL CALL ARGUMENTS PARSING WITH MINIMAX RESPONSES
+    // ═══════════════════════════════════════════════════════
+
+    @Test
+    fun `parse tool call arguments - list_directory from MiniMax`() {
+        val arguments = """
+        {
+            "action": "list_directory",
+            "args": {"path": "/ext/subghz"},
+            "justification": "User wants SubGHz files",
+            "expected_effect": "List directory contents"
+        }
+        """.trimIndent()
+
+        val cmd = json.decodeFromString<com.vesper.flipper.domain.model.ExecuteCommand>(arguments)
+        assertEquals(com.vesper.flipper.domain.model.CommandAction.LIST_DIRECTORY, cmd.action)
+        assertEquals("/ext/subghz", cmd.args.path)
+    }
+
+    @Test
+    fun `parse tool call arguments - execute_cli from MiniMax`() {
+        val arguments = """
+        {
+            "action": "execute_cli",
+            "args": {"command": "storage list /ext"},
+            "justification": "Check storage contents",
+            "expected_effect": "Return directory listing"
+        }
+        """.trimIndent()
+
+        val cmd = json.decodeFromString<com.vesper.flipper.domain.model.ExecuteCommand>(arguments)
+        assertEquals(com.vesper.flipper.domain.model.CommandAction.EXECUTE_CLI, cmd.action)
+        assertEquals("storage list /ext", cmd.args.command)
+    }
+
+    @Test
+    fun `parse tool call arguments - forge_payload from MiniMax`() {
+        val arguments = """
+        {
+            "action": "forge_payload",
+            "args": {"prompt": "Create a BadUSB that opens notepad", "payload_type": "BAD_USB"},
+            "justification": "User requested BadUSB script",
+            "expected_effect": "Generate BadUSB payload"
+        }
+        """.trimIndent()
+
+        val cmd = json.decodeFromString<com.vesper.flipper.domain.model.ExecuteCommand>(arguments)
+        assertEquals(com.vesper.flipper.domain.model.CommandAction.FORGE_PAYLOAD, cmd.action)
+        assertEquals("Create a BadUSB that opens notepad", cmd.args.prompt)
+    }
+
+    // ═══════════════════════════════════════════════════════
+    // 7. RESPONSE FORMAT COMPATIBILITY
+    // ═══════════════════════════════════════════════════════
+
+    @Test
+    fun `minimax response with content as array of parts`() {
+        val responseJson = """
+        {
+            "id": "cmpl-parts",
+            "model": "MiniMax-M2.7",
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "Part one."},
+                        {"type": "text", "text": "Part two."}
+                    ]
+                },
+                "finish_reason": "stop"
+            }],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+        }
+        """.trimIndent()
+
+        val response = json.decodeFromString<OpenRouterResponse>(responseJson)
+        val text = response.choices[0].message.textContent
+        assertEquals("Part one.\nPart two.", text)
+    }
+
+    @Test
+    fun `minimax response with null content and tool calls`() {
+        val responseJson = """
+        {
+            "id": "cmpl-tools",
+            "model": "MiniMax-M2.7",
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "tc_1",
+                        "type": "function",
+                        "function": {
+                            "name": "execute_command",
+                            "arguments": "{\"action\":\"get_device_info\",\"args\":{}}"
+                        }
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }],
+            "usage": {"prompt_tokens": 50, "completion_tokens": 20, "total_tokens": 70}
+        }
+        """.trimIndent()
+
+        val response = json.decodeFromString<OpenRouterResponse>(responseJson)
+        val message = response.choices[0].message
+        assertNull(message.textContent)
+        assertNotNull(message.toolCalls)
+        assertEquals("tc_1", message.toolCalls!![0].id)
+    }
+
+    @Test
+    fun `minimax response with arguments as json object`() {
+        // Some models return arguments as a JSON object instead of a string
+        val responseJson = """
+        {
+            "id": "cmpl-obj-args",
+            "model": "MiniMax-M2.7",
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [{
+                        "id": "tc_2",
+                        "type": "function",
+                        "function": {
+                            "name": "execute_command",
+                            "arguments": {"action":"list_directory","args":{"path":"/ext"}}
+                        }
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }],
+            "usage": {"prompt_tokens": 30, "completion_tokens": 15, "total_tokens": 45}
+        }
+        """.trimIndent()
+
+        val response = json.decodeFromString<OpenRouterResponse>(responseJson)
+        val args = response.choices[0].message.toolCalls!![0].function.arguments
+        assertTrue("Arguments should contain list_directory", args.contains("list_directory"))
+    }
+
+    // ═══════════════════════════════════════════════════════
+    // 8. EDGE CASES
+    // ═══════════════════════════════════════════════════════
+
+    @Test
+    fun `minimax response with empty choices`() {
+        val responseJson = """
+        {
+            "id": "cmpl-empty",
+            "model": "MiniMax-M2.7",
+            "choices": [],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 0, "total_tokens": 10}
+        }
+        """.trimIndent()
+
+        val response = json.decodeFromString<OpenRouterResponse>(responseJson)
+        assertTrue(response.choices.isEmpty())
+    }
+
+    @Test
+    fun `minimax response missing usage field`() {
+        val responseJson = """
+        {
+            "id": "cmpl-no-usage",
+            "model": "MiniMax-M2.5-highspeed",
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": "Quick response"
+                },
+                "finish_reason": "stop"
+            }]
+        }
+        """.trimIndent()
+
+        val response = json.decodeFromString<OpenRouterResponse>(responseJson)
+        assertEquals("Quick response", response.choices[0].message.textContent)
+        assertNull(response.usage)
+    }
+}


### PR DESCRIPTION
## Summary

- Add **MiniMax** as a direct LLM provider alongside OpenRouter
- Users can switch between providers in **Settings > LLM Provider**
- MiniMax models: M2.7, M2.7-highspeed, M2.5, M2.5-highspeed (1M / 204K context)
- Full tool-calling support with `execute_command` — all 32 Flipper actions work
- Temperature clamping (0,1] and `<think>` tag stripping for MiniMax models
- Settings UI: provider dropdown, conditional API key field, per-provider model list

## Changes

| File | What |
|------|------|
| `LlmProvider.kt` | Provider enum (OPEN_ROUTER, MINIMAX) |
| `MiniMaxClient.kt` | OpenAI-compatible client with rate limiting, retry, tool calling |
| `OpenRouterClient.kt` | Expose shared constants for MiniMaxClient reuse |
| `VesperAgent.kt` | Route chat() to selected provider; keep OpenRouter for vision |
| `SettingsStore.kt` | MiniMax API key + provider preference persistence |
| `SettingsScreen.kt` | Provider selector, conditional API key field, dynamic model list |
| `SettingsViewModel.kt` | Provider/MiniMax state management |
| `README.md` | MiniMax models table, setup instructions, architecture diagram |

## Test plan

- [x] 28 unit tests covering thinking-tag stripping, response parsing, model catalog, provider enum, tool-call arguments, edge cases
- [x] 3 integration tests (require `MINIMAX_API_KEY` env var, auto-skipped otherwise)
- [ ] Manual: switch provider to MiniMax, enter API key, verify chat works
- [ ] Manual: verify OpenRouter still works after switching back
- [ ] Manual: verify model dropdown updates per provider

10 files changed, 1,458 additions, 62 deletions