### PR TITLE
Add desktop bridge transport and RAW import support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -85,6 +85,14 @@ android {
         buildConfig = true
     }
 
+    defaultConfig {
+        buildConfigField(
+            "String",
+            "OPENROUTER_DEFAULT_MODEL",
+            "\"${localProps.getProperty("OPENROUTER_DEFAULT_MODEL", "").replace("\"", "\\\"")}\""
+        )
+    }
+
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
@@ -155,4 +163,8 @@ dependencies {
 
     // Diff utils
     implementation("io.github.java-diff-utils:java-diff-utils:4.12")
+
+    // Unit tests
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.mockito.kotlin:mockito-kotlin:5.4.0")
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -89,7 +89,7 @@ android {
         buildConfigField(
             "String",
             "OPENROUTER_DEFAULT_MODEL",
-            "\"${localProps.getProperty("OPENROUTER_DEFAULT_MODEL", "").replace("\"", "\\\"")}\""
+            "\"${localProps.getProperty("OPENROUTER_DEFAULT_MODEL", "openrouter/auto").replace("\"", "\\\"")}\""
         )
     }
 

--- a/app/src/main/java/com/vesper/flipper/ai/OpenRouterClient.kt
+++ b/app/src/main/java/com/vesper/flipper/ai/OpenRouterClient.kt
@@ -136,6 +136,7 @@ class OpenRouterClient @Inject constructor(
                     apiKey = apiKey,
                     model = candidateModel,
                     messages = requestMessages,
+                    sessionId = sessionId,
                     includeGlassesActions = glassesEnabled
                 )
             )
@@ -438,6 +439,7 @@ class OpenRouterClient @Inject constructor(
         apiKey: String,
         model: String,
         messages: List<OpenRouterMessage>,
+        sessionId: String? = null,
         includeGlassesActions: Boolean = false
     ): Request {
         val tool = if (includeGlassesActions) EXECUTE_COMMAND_TOOL else buildToolWithoutGlasses()
@@ -446,6 +448,7 @@ class OpenRouterClient @Inject constructor(
             messages = messages,
             tools = listOf(tool),
             toolChoice = "auto",
+            sessionId = sessionId?.takeIf { it.isNotBlank() },
             maxTokens = TOOL_CALL_RESPONSE_MAX_TOKENS
         )
 
@@ -1737,6 +1740,8 @@ data class OpenRouterRequest(
     val tools: List<OpenRouterTool>? = null,
     @SerialName("tool_choice")
     val toolChoice: String? = null,
+    @SerialName("session_id")
+    val sessionId: String? = null,
     @SerialName("max_tokens")
     val maxTokens: Int? = null
 )

--- a/app/src/main/java/com/vesper/flipper/ble/BleServiceManager.kt
+++ b/app/src/main/java/com/vesper/flipper/ble/BleServiceManager.kt
@@ -144,6 +144,13 @@ class BleServiceManager @Inject constructor(
         }
     }
 
+    fun connectDesktopBridge() {
+        managerScope.launch {
+            val service = awaitService() ?: return@launch
+            service.connectDesktopBridgeIfAvailable()
+        }
+    }
+
     /**
      * Disconnect from current device
      */

--- a/app/src/main/java/com/vesper/flipper/ble/FlipperBleService.kt
+++ b/app/src/main/java/com/vesper/flipper/ble/FlipperBleService.kt
@@ -28,6 +28,7 @@ import com.hoho.android.usbserial.driver.ProbeTable
 import com.hoho.android.usbserial.driver.UsbSerialDriver
 import com.hoho.android.usbserial.driver.UsbSerialPort
 import com.hoho.android.usbserial.driver.UsbSerialProber
+import com.vesper.flipper.BuildConfig
 import com.vesper.flipper.MainActivity
 import com.vesper.flipper.R
 import com.vesper.flipper.VesperApplication
@@ -36,6 +37,11 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.io.EOFException
+import java.net.InetSocketAddress
+import java.net.Socket
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
@@ -59,6 +65,12 @@ class FlipperBleService : Service() {
     private var usbDeviceConnection: UsbDeviceConnection? = null
     private var connectedUsbDevice: UsbDevice? = null
     private var usbReadJob: Job? = null
+    private var desktopBridgeSocket: Socket? = null
+    private var desktopBridgeInput: DataInputStream? = null
+    private var desktopBridgeOutput: DataOutputStream? = null
+    private var desktopBridgeReadJob: Job? = null
+    private var desktopBridgeHost: String? = null
+    private var desktopBridgePort: Int? = null
     private var bleKeepaliveJob: Job? = null
     private var usbReceiverRegistered = false
     private var broadScanStarted = false
@@ -522,6 +534,64 @@ class FlipperBleService : Service() {
         }
     }
 
+    fun connectDesktopBridgeIfAvailable(host: String = "10.0.2.2", port: Int = 8765) {
+        serviceScope.launch {
+            stopScan()
+            disconnect()
+            connectDesktopBridgeInternal(host, port)
+        }
+    }
+
+    private suspend fun connectDesktopBridgeInternal(host: String, port: Int): Boolean {
+        if (!BuildConfig.DEBUG) {
+            _connectionState.value = ConnectionState.Error("Desktop Bridge is only available in debug builds")
+            updateNotification()
+            return false
+        }
+
+        _connectionState.value = ConnectionState.Connecting("Desktop Bridge")
+        updateNotification()
+
+        return try {
+            val socket = withContext(Dispatchers.IO) {
+                Socket().apply {
+                    tcpNoDelay = true
+                    connect(InetSocketAddress(host, port), DESKTOP_BRIDGE_CONNECT_TIMEOUT_MS)
+                }
+            }
+
+            desktopBridgeSocket = socket
+            desktopBridgeInput = DataInputStream(socket.getInputStream())
+            desktopBridgeOutput = DataOutputStream(socket.getOutputStream())
+            desktopBridgeHost = host
+            desktopBridgePort = port
+            activeTransport = CommandTransport.DESKTOP_BRIDGE
+            flipperProtocol.onConnectionReset()
+            startDesktopBridgeReadLoop()
+
+            _connectedDevice.value = FlipperDevice(
+                address = "desktop:$host:$port",
+                name = "Desktop Bridge (USB)",
+                rssi = 0,
+                isConfirmedFlipper = true
+            )
+            _connectionState.value = ConnectionState.Connected("Desktop Bridge (USB)")
+            updateNotification()
+
+            serviceScope.launch {
+                flipperProtocol.probeCliAvailability(force = true)
+            }
+            true
+        } catch (t: Throwable) {
+            disconnectDesktopBridgeTransport(setState = false)
+            _connectionState.value = ConnectionState.Error(
+                "Desktop Bridge connect failed: ${t.message ?: t::class.java.simpleName}"
+            )
+            updateNotification()
+            false
+        }
+    }
+
     private suspend fun connectUsbInternal(preferredDevice: UsbDevice? = null): Boolean {
         val manager = usbManager ?: run {
             _connectionState.value = ConnectionState.Error("USB host manager unavailable")
@@ -846,6 +916,42 @@ class FlipperBleService : Service() {
         }
     }
 
+    private fun startDesktopBridgeReadLoop() {
+        desktopBridgeReadJob?.cancel()
+        desktopBridgeReadJob = serviceScope.launch {
+            val input = desktopBridgeInput ?: return@launch
+            while (isActive && activeTransport == CommandTransport.DESKTOP_BRIDGE) {
+                try {
+                    val size = withContext(Dispatchers.IO) { input.readInt() }
+                    if (size < 0 || size > DESKTOP_BRIDGE_MAX_FRAME_BYTES) {
+                        throw IllegalStateException("Invalid bridge frame size: $size")
+                    }
+                    val payload = ByteArray(size)
+                    withContext(Dispatchers.IO) { input.readFully(payload) }
+                    if (payload.isNotEmpty()) {
+                        completePendingOperation(payload)
+                        flipperProtocol.processIncomingData(payload)
+                    }
+                } catch (cancelled: CancellationException) {
+                    throw cancelled
+                } catch (eof: EOFException) {
+                    disconnectDesktopBridgeTransport(
+                        setState = true,
+                        errorMessage = "Desktop Bridge disconnected"
+                    )
+                    break
+                } catch (t: Throwable) {
+                    Log.w(TAG, "Desktop Bridge read failed: ${t.message}")
+                    disconnectDesktopBridgeTransport(
+                        setState = true,
+                        errorMessage = "Desktop Bridge error: ${t.message ?: "read failed"}"
+                    )
+                    break
+                }
+            }
+        }
+    }
+
     private fun markBleActivity() {
         lastBleActivityAtMs = System.currentTimeMillis()
     }
@@ -914,6 +1020,7 @@ class FlipperBleService : Service() {
         stopBleKeepalive()
         disconnectBleTransport()
         disconnectUsbTransport(setState = false)
+        disconnectDesktopBridgeTransport(setState = false)
         _connectedDevice.value = null
         activeTransport = CommandTransport.NONE
         if (_connectionState.value !is ConnectionState.Error) {
@@ -969,6 +1076,35 @@ class FlipperBleService : Service() {
         pendingUsbPermissionRequest?.cancel()
         pendingUsbPermissionRequest = null
         if (activeTransport == CommandTransport.USB) {
+            activeTransport = CommandTransport.NONE
+        }
+        if (setState) {
+            _connectedDevice.value = null
+            _connectionState.value = if (!errorMessage.isNullOrBlank()) {
+                ConnectionState.Error(errorMessage)
+            } else {
+                ConnectionState.Disconnected
+            }
+            updateNotification()
+            flipperProtocol.onConnectionReset()
+        }
+    }
+
+    private fun disconnectDesktopBridgeTransport(
+        setState: Boolean,
+        errorMessage: String? = null
+    ) {
+        desktopBridgeReadJob?.cancel()
+        desktopBridgeReadJob = null
+        runCatching { desktopBridgeInput?.close() }
+        runCatching { desktopBridgeOutput?.close() }
+        runCatching { desktopBridgeSocket?.close() }
+        desktopBridgeInput = null
+        desktopBridgeOutput = null
+        desktopBridgeSocket = null
+        desktopBridgeHost = null
+        desktopBridgePort = null
+        if (activeTransport == CommandTransport.DESKTOP_BRIDGE) {
             activeTransport = CommandTransport.NONE
         }
         if (setState) {
@@ -1267,10 +1403,10 @@ class FlipperBleService : Service() {
             return false
         }
 
-        return if (isUsbCommandTransportConnected()) {
-            sendDataOverUsb(data, preferNoResponse)
-        } else {
-            sendDataOverBle(data, preferNoResponse, ignoreOverflowBudget)
+        return when {
+            isUsbCommandTransportConnected() -> sendDataOverUsb(data, preferNoResponse)
+            isDesktopBridgeCommandTransportConnected() -> sendDataOverDesktopBridge(data, preferNoResponse)
+            else -> sendDataOverBle(data, preferNoResponse, ignoreOverflowBudget)
         }
     }
 
@@ -1300,6 +1436,35 @@ class FlipperBleService : Service() {
                     true
                 } catch (t: Throwable) {
                     lastWriteFailureReason = "USB write failed: ${t.message ?: t::class.java.simpleName}"
+                    false
+                }
+            }
+        } ?: return false
+        return writeResult
+    }
+
+    private suspend fun sendDataOverDesktopBridge(
+        data: ByteArray,
+        preferNoResponse: Boolean
+    ): Boolean {
+        val output = desktopBridgeOutput ?: run {
+            lastWriteFailureReason = "Desktop Bridge output unavailable"
+            return false
+        }
+        val lockTimeoutMs = resolveWriteLockTimeoutMs(data.size, preferNoResponse)
+        val writeResult = withWriteMutexOrFail(
+            lockTimeoutMs = lockTimeoutMs,
+            timeoutReason = "Desktop Bridge write queue busy (timeout waiting for writer lock)"
+        ) {
+            withContext(Dispatchers.IO) {
+                try {
+                    output.writeInt(data.size)
+                    output.write(data)
+                    output.flush()
+                    lastWriteFailureReason = null
+                    true
+                } catch (t: Throwable) {
+                    lastWriteFailureReason = "Desktop Bridge write failed: ${t.message ?: t::class.java.simpleName}"
                     false
                 }
             }
@@ -1797,7 +1962,9 @@ class FlipperBleService : Service() {
     }
 
     fun isCommandTransportConnected(): Boolean {
-        return isUsbCommandTransportConnected() || isBleCommandTransportConnected()
+        return isUsbCommandTransportConnected() ||
+                isDesktopBridgeCommandTransportConnected() ||
+                isBleCommandTransportConnected()
     }
 
     private fun isBleCommandTransportConnected(): Boolean {
@@ -1815,6 +1982,16 @@ class FlipperBleService : Service() {
                 usbSerialPort != null &&
                 usbDeviceConnection != null &&
                 usbReadJob?.isActive == true &&
+                _connectionState.value is ConnectionState.Connected
+    }
+
+    private fun isDesktopBridgeCommandTransportConnected(): Boolean {
+        return activeTransport == CommandTransport.DESKTOP_BRIDGE &&
+                desktopBridgeSocket?.isConnected == true &&
+                desktopBridgeSocket?.isClosed == false &&
+                desktopBridgeInput != null &&
+                desktopBridgeOutput != null &&
+                desktopBridgeReadJob?.isActive == true &&
                 _connectionState.value is ConnectionState.Connected
     }
 
@@ -1871,6 +2048,11 @@ class FlipperBleService : Service() {
                         val usbName = usbDevice?.let { resolveUsbDeviceName(it) } ?: "USB"
                         val baud = currentUsbBaudRate?.toString() ?: "default"
                         ConnectionCheckLevel.PASS to "Connected over USB: $usbName (baud=$baud)"
+                    }
+                    transportConnected && activeMode == CommandTransport.DESKTOP_BRIDGE -> {
+                        val host = desktopBridgeHost ?: "unknown"
+                        val port = desktopBridgePort?.toString() ?: "unknown"
+                        ConnectionCheckLevel.PASS to "Connected over Desktop Bridge: $host:$port"
                     }
                     transportConnected -> ConnectionCheckLevel.PASS to
                             "Connected. mtu=$negotiatedMtu tx=$writeUuid rx=$notifyUuid"
@@ -2486,6 +2668,8 @@ class FlipperBleService : Service() {
         private const val USB_READ_BUFFER_SIZE_BYTES = 4096
         private const val USB_WRITE_CHUNK_SIZE_BYTES = 256
         private const val USB_WRITE_INTER_CHUNK_DELAY_MS = 2L
+        private const val DESKTOP_BRIDGE_CONNECT_TIMEOUT_MS = 2_000
+        private const val DESKTOP_BRIDGE_MAX_FRAME_BYTES = 1024 * 1024
         private const val USB_DATA_BITS = 8
         private const val USB_RPC_PRIME_DRAIN_WINDOW_MS = 220L
         private const val USB_RPC_BAUD_RETRY_DRAIN_WINDOW_MS = 160L
@@ -2523,7 +2707,8 @@ class FlipperBleService : Service() {
 private enum class CommandTransport {
     NONE,
     BLE,
-    USB
+    USB,
+    DESKTOP_BRIDGE
 }
 
 /**

--- a/app/src/main/java/com/vesper/flipper/data/SettingsStore.kt
+++ b/app/src/main/java/com/vesper/flipper/data/SettingsStore.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.*
 import androidx.datastore.preferences.preferencesDataStore
+import com.vesper.flipper.BuildConfig
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -34,7 +35,9 @@ class SettingsStore @Inject constructor(
     private val SELECTED_MODEL = stringPreferencesKey("selected_model")
 
     val selectedModel: Flow<String> = context.dataStore.data.map { preferences ->
-        preferences[SELECTED_MODEL] ?: DEFAULT_MODEL
+        preferences[SELECTED_MODEL]
+            ?: BuildConfig.OPENROUTER_DEFAULT_MODEL.takeIf { it.isNotBlank() }
+            ?: DEFAULT_MODEL
     }
 
     suspend fun setSelectedModel(model: String) {
@@ -311,6 +314,7 @@ class SettingsStore @Inject constructor(
 
         // Used when fetching live catalog fails (offline/rate-limited).
         val FALLBACK_MODELS = listOf(
+            ModelInfo("openrouter/auto", "Auto Router", "OpenRouter intelligent model selection"),
             ModelInfo("nousresearch/hermes-4-405b", "Hermes 4 405B", "Largest Hermes 4"),
             ModelInfo("anthropic/claude-sonnet-4.5", "Claude Sonnet 4.5", "Latest Anthropic"),
             ModelInfo("openai/gpt-oss-120b", "GPT-OSS 120B", "Latest OpenAI"),

--- a/app/src/main/java/com/vesper/flipper/domain/model/Alchemy.kt
+++ b/app/src/main/java/com/vesper/flipper/domain/model/Alchemy.kt
@@ -240,7 +240,8 @@ data class SignalLayer(
     val volume: Float = 1.0f,
     val pattern: BitPattern,
     val timing: TimingConfig,
-    val color: Long = 0xFFFF6B00
+    val color: Long = 0xFFFF6B00,
+    val rawTimings: List<Int>? = null
 )
 
 enum class LayerType(val displayName: String, val icon: String) {
@@ -328,6 +329,7 @@ object SignalAlchemist {
     }
 
     private fun generateLayerData(layer: SignalLayer, modulation: ModulationType): List<Int> {
+        layer.rawTimings?.let { return it }
         return when (layer.type) {
             LayerType.CARRIER -> listOf(layer.pattern.bitDuration * layer.pattern.bits.size)
             LayerType.DATA -> generateDataBits(layer)
@@ -417,7 +419,10 @@ object SignalAlchemist {
                 }
             }
         }
-        return result.map { (it * layer.volume).toInt() }
+        return result.map { timing ->
+            val scaled = (timing * layer.volume).toInt()
+            if (scaled != 0) scaled else if (timing > 0) 1 else -1
+        }
     }
 
     fun exportToFlipperFormat(project: AlchemyProject): String {
@@ -436,10 +441,72 @@ object SignalAlchemist {
         }
     }
 
+    fun canImportSubGhzRaw(content: String): Boolean {
+        val lines = content.lineSequence().map { it.trim() }
+        var hasRawProtocol = false
+        var hasRawData = false
+        for (line in lines) {
+            hasRawProtocol = hasRawProtocol || line.startsWith("Protocol:") && line.substringAfter(":").trim() == "RAW"
+            hasRawData = hasRawData || line.startsWith("RAW_Data:")
+            if (hasRawProtocol && hasRawData) return true
+        }
+        return false
+    }
+
+    fun importSubGhzRaw(content: String, name: String = "Imported RAW"): AlchemyProject? {
+        if (!canImportSubGhzRaw(content)) return null
+
+        val lines = content.lines().map { it.trim() }
+        val frequency = lines.firstNotNullOfOrNull { line ->
+            line.takeIf { it.startsWith("Frequency:") }?.substringAfter(":")?.trim()?.toLongOrNull()
+        } ?: return null
+        val preset = SignalPreset.entries.minByOrNull { kotlin.math.abs(it.frequency - frequency) } ?: SignalPreset.CUSTOM
+        val modulation = lines.firstNotNullOfOrNull { line ->
+            line.takeIf { it.startsWith("Preset:") }?.substringAfter(":")?.trim()?.let { presetName ->
+                ModulationType.entries.firstOrNull { it.flipperPreset == presetName }
+            }
+        } ?: ModulationType.CUSTOM
+        val timings = lines
+            .filter { it.startsWith("RAW_Data:") }
+            .flatMap { it.substringAfter(":").trim().split("\\s+".toRegex()) }
+            .mapNotNull { it.toIntOrNull() }
+            .filter { it != 0 }
+
+        if (timings.size < 2) return null
+
+        val bitDuration = timings
+            .map { kotlin.math.abs(it) }
+            .sorted()
+            .let { it[it.size / 2] }
+            .coerceIn(50, 5000)
+
+        return AlchemyProject(
+            name = name,
+            frequency = frequency,
+            modulation = modulation,
+            preset = preset,
+            layers = listOf(
+                SignalLayer(
+                    name = "Imported RAW",
+                    type = LayerType.DATA,
+                    pattern = BitPattern(
+                        bits = timings.map { it > 0 },
+                        bitDuration = bitDuration,
+                        encoding = BitEncoding.NRZ
+                    ),
+                    timing = TimingConfig(),
+                    color = 0xFFFF6B00,
+                    rawTimings = timings
+                )
+            )
+        )
+    }
+
     fun generateWaveformPreview(project: AlchemyProject, width: Int = 500): List<Float> {
         val rawData = synthesize(project)
         if (rawData.isEmpty()) return List(width) { 0.5f }
         val totalDuration = rawData.sumOf { kotlin.math.abs(it) }
+        if (totalDuration == 0) return List(width) { 0.5f }
         val samplesPerUnit = width.toFloat() / totalDuration
         val samples = mutableListOf<Float>()
         rawData.forEach { timing ->

--- a/app/src/main/java/com/vesper/flipper/ui/screen/AlchemyLabScreen.kt
+++ b/app/src/main/java/com/vesper/flipper/ui/screen/AlchemyLabScreen.kt
@@ -16,7 +16,9 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.*
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -47,6 +49,12 @@ fun AlchemyLabScreen(
     val isLoadingVault by viewModel.isLoadingVault.collectAsState()
     val vaultStats by viewModel.vaultStats.collectAsState()
     val message by viewModel.message.collectAsState()
+    val project by viewModel.project.collectAsState()
+    val waveformPreview by viewModel.waveformPreview.collectAsState()
+    val selectedLayerIndex by viewModel.selectedLayerIndex.collectAsState()
+    val isPlaying by viewModel.isPlaying.collectAsState()
+    val showExportDialog by viewModel.showExportDialog.collectAsState()
+    val exportedCode by viewModel.exportedCode.collectAsState()
 
     LaunchedEffect(message) {
         message?.let {
@@ -119,11 +127,43 @@ fun AlchemyLabScreen(
                         BlueprintCard(
                             blueprint = bp,
                             onDeploy = { viewModel.deployBlueprint() },
+                            canOpenInEditor = viewModel.canOpenBlueprintInEditor(bp),
+                            onOpenInEditor = { viewModel.openBlueprintInEditor() },
                             onEditSection = { viewModel.editBlueprintSection(it) },
                             onDismiss = { viewModel.clearBlueprint() }
                         )
                     }
                 }
+            }
+
+            item {
+                RfEditorSection(
+                    project = project,
+                    waveformPreview = waveformPreview,
+                    selectedLayerIndex = selectedLayerIndex,
+                    isPlaying = isPlaying,
+                    isSaving = isSaving,
+                    onProjectNameChange = { viewModel.updateProjectName(it) },
+                    onFrequencyChange = { viewModel.updateFrequency(it) },
+                    onPresetChange = { viewModel.selectPreset(it) },
+                    onModulationChange = { viewModel.updateModulation(it) },
+                    onSelectLayer = { viewModel.selectLayer(it) },
+                    onToggleLayer = { viewModel.toggleLayerEnabled(it) },
+                    onDuplicateLayer = { viewModel.duplicateLayer(it) },
+                    onMoveLayerUp = { viewModel.moveLayerUp(it) },
+                    onMoveLayerDown = { viewModel.moveLayerDown(it) },
+                    onRemoveLayer = { viewModel.removeLayer(it) },
+                    onAddLayer = { viewModel.addLayer(it) },
+                    onLayerVolumeChange = { index, volume -> viewModel.updateLayerVolume(index, volume) },
+                    onLayerBitDurationChange = { index, duration -> viewModel.updateLayerBitDuration(index, duration) },
+                    onLayerEncodingChange = { index, encoding -> viewModel.updateLayerEncoding(index, encoding) },
+                    onLayerRepeatCountChange = { index, count -> viewModel.updateLayerRepeatCount(index, count) },
+                    onLayerBitsChange = { index, hex -> viewModel.updateLayerBits(index, hex) },
+                    onNewProject = { viewModel.newProject() },
+                    onPreview = { viewModel.playPreview() },
+                    onExport = { viewModel.showExport() },
+                    onSave = { viewModel.saveToFlipper() }
+                )
             }
 
             // ═══════════════════ THE VAULT ═══════════════════
@@ -212,6 +252,15 @@ fun AlchemyLabScreen(
                 onSave = { viewModel.saveWorkbench() },
                 onDismiss = { viewModel.closeWorkbench() },
                 isSaving = isSaving
+            )
+        }
+
+        if (showExportDialog) {
+            ExportDialog(
+                content = exportedCode.orEmpty(),
+                isSaving = isSaving,
+                onSave = { viewModel.saveToFlipper() },
+                onDismiss = { viewModel.hideExport() }
             )
         }
     }
@@ -313,6 +362,8 @@ private fun TheForgeSection(
 private fun BlueprintCard(
     blueprint: ForgeBlueprint,
     onDeploy: () -> Unit,
+    canOpenInEditor: Boolean,
+    onOpenInEditor: () -> Unit,
     onEditSection: (Int) -> Unit,
     onDismiss: () -> Unit
 ) {
@@ -393,29 +444,308 @@ private fun BlueprintCard(
             Spacer(modifier = Modifier.height(8.dp))
             Text("Target: ${blueprint.flipperPath}", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant, fontFamily = FontFamily.Monospace)
 
-            // Deploy Button
             Spacer(modifier = Modifier.height(12.dp))
-            Button(
-                onClick = onDeploy,
-                modifier = Modifier.fillMaxWidth(),
-                enabled = blueprint.status == ForgeStatus.BLUEPRINT,
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = when (blueprint.status) {
-                        ForgeStatus.FORGED -> RiskLow; ForgeStatus.FAILED -> RiskHigh; else -> VesperOrange
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                if (canOpenInEditor) {
+                    OutlinedButton(
+                        onClick = onOpenInEditor,
+                        modifier = Modifier.weight(1f),
+                        shape = RoundedCornerShape(12.dp)
+                    ) {
+                        Icon(Icons.Default.Tune, null)
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text("Open in RF Editor", fontWeight = FontWeight.Bold)
                     }
-                ),
-                shape = RoundedCornerShape(12.dp)
-            ) {
-                when (blueprint.status) {
-                    ForgeStatus.BLUEPRINT -> { Icon(Icons.Default.RocketLaunch, null); Spacer(modifier = Modifier.width(8.dp)); Text("Deploy to Flipper", fontWeight = FontWeight.Bold) }
-                    ForgeStatus.FORGING -> { CircularProgressIndicator(modifier = Modifier.size(20.dp), color = Color.White, strokeWidth = 2.dp); Spacer(modifier = Modifier.width(8.dp)); Text("Deploying...") }
-                    ForgeStatus.FORGED -> { Icon(Icons.Default.CheckCircle, null); Spacer(modifier = Modifier.width(8.dp)); Text("Deployed!") }
-                    ForgeStatus.FAILED -> { Icon(Icons.Default.Error, null); Spacer(modifier = Modifier.width(8.dp)); Text("Failed") }
+                }
+                Button(
+                    onClick = onDeploy,
+                    modifier = Modifier.weight(1f),
+                    enabled = blueprint.status == ForgeStatus.BLUEPRINT,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = when (blueprint.status) {
+                            ForgeStatus.FORGED -> RiskLow; ForgeStatus.FAILED -> RiskHigh; else -> VesperOrange
+                        }
+                    ),
+                    shape = RoundedCornerShape(12.dp)
+                ) {
+                    when (blueprint.status) {
+                        ForgeStatus.BLUEPRINT -> { Icon(Icons.Default.RocketLaunch, null); Spacer(modifier = Modifier.width(8.dp)); Text("Deploy", fontWeight = FontWeight.Bold) }
+                        ForgeStatus.FORGING -> { CircularProgressIndicator(modifier = Modifier.size(20.dp), color = Color.White, strokeWidth = 2.dp); Spacer(modifier = Modifier.width(8.dp)); Text("Deploying...") }
+                        ForgeStatus.FORGED -> { Icon(Icons.Default.CheckCircle, null); Spacer(modifier = Modifier.width(8.dp)); Text("Deployed!") }
+                        ForgeStatus.FAILED -> { Icon(Icons.Default.Error, null); Spacer(modifier = Modifier.width(8.dp)); Text("Failed") }
+                    }
                 }
             }
         }
     }
 }
+
+@Composable
+private fun RfEditorSection(
+    project: AlchemyProject,
+    waveformPreview: List<Float>,
+    selectedLayerIndex: Int?,
+    isPlaying: Boolean,
+    isSaving: Boolean,
+    onProjectNameChange: (String) -> Unit,
+    onFrequencyChange: (Long) -> Unit,
+    onPresetChange: (SignalPreset) -> Unit,
+    onModulationChange: (ModulationType) -> Unit,
+    onSelectLayer: (Int?) -> Unit,
+    onToggleLayer: (Int) -> Unit,
+    onDuplicateLayer: (Int) -> Unit,
+    onMoveLayerUp: (Int) -> Unit,
+    onMoveLayerDown: (Int) -> Unit,
+    onRemoveLayer: (Int) -> Unit,
+    onAddLayer: (LayerType) -> Unit,
+    onLayerVolumeChange: (Int, Float) -> Unit,
+    onLayerBitDurationChange: (Int, Int) -> Unit,
+    onLayerEncodingChange: (Int, BitEncoding) -> Unit,
+    onLayerRepeatCountChange: (Int, Int) -> Unit,
+    onLayerBitsChange: (Int, String) -> Unit,
+    onNewProject: () -> Unit,
+    onPreview: () -> Unit,
+    onExport: () -> Unit,
+    onSave: () -> Unit
+) {
+    val selectedLayer = selectedLayerIndex?.let { project.layers.getOrNull(it) }
+    var addMenuOpen by remember { mutableStateOf(false) }
+    var modulationMenuOpen by remember { mutableStateOf(false) }
+    var encodingMenuOpen by remember { mutableStateOf(false) }
+
+    Card(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f)),
+        border = BorderStroke(1.dp, VesperAccent.copy(alpha = 0.25f))
+    ) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(Icons.Default.Tune, null, tint = VesperAccent, modifier = Modifier.size(20.dp))
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text("RF EDITOR", style = MaterialTheme.typography.labelLarge, color = VesperAccent, letterSpacing = 2.sp)
+                }
+                Text("${project.layers.size} layers", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+
+            OutlinedTextField(
+                value = project.name,
+                onValueChange = onProjectNameChange,
+                label = { Text("Project") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                colors = OutlinedTextFieldDefaults.colors(focusedBorderColor = VesperAccent, cursorColor = VesperAccent)
+            )
+
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = project.frequency.toString(),
+                    onValueChange = { it.toLongOrNull()?.let(onFrequencyChange) },
+                    label = { Text("Frequency Hz") },
+                    modifier = Modifier.weight(1f),
+                    singleLine = true,
+                    colors = OutlinedTextFieldDefaults.colors(focusedBorderColor = VesperAccent, cursorColor = VesperAccent)
+                )
+                Box(modifier = Modifier.weight(1f)) {
+                    OutlinedButton(onClick = { modulationMenuOpen = true }, modifier = Modifier.fillMaxWidth().height(56.dp)) {
+                        Text(project.modulation.displayName, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                        Icon(Icons.Default.ExpandMore, null)
+                    }
+                    DropdownMenu(expanded = modulationMenuOpen, onDismissRequest = { modulationMenuOpen = false }) {
+                        ModulationType.entries.forEach { modulation ->
+                            DropdownMenuItem(
+                                text = { Text(modulation.displayName) },
+                                onClick = { onModulationChange(modulation); modulationMenuOpen = false }
+                            )
+                        }
+                    }
+                }
+            }
+
+            LazyRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                items(SignalPreset.entries) { preset ->
+                    FilterChip(
+                        selected = project.preset == preset,
+                        onClick = { onPresetChange(preset) },
+                        label = { Text(preset.displayName) },
+                        colors = FilterChipDefaults.filterChipColors(selectedContainerColor = VesperAccent, selectedLabelColor = Color.White)
+                    )
+                }
+            }
+
+            RfWaveformPreview(samples = waveformPreview, modifier = Modifier.fillMaxWidth().height(120.dp))
+
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedButton(onClick = onNewProject, modifier = Modifier.weight(1f)) { Icon(Icons.Default.Add, null); Spacer(modifier = Modifier.width(6.dp)); Text("New") }
+                OutlinedButton(onClick = onPreview, enabled = !isPlaying, modifier = Modifier.weight(1f)) {
+                    if (isPlaying) CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                    else Icon(Icons.Default.PlayArrow, null)
+                    Spacer(modifier = Modifier.width(6.dp))
+                    Text(if (isPlaying) "Playing" else "Preview")
+                }
+                OutlinedButton(onClick = onExport, modifier = Modifier.weight(1f)) { Icon(Icons.Default.IosShare, null); Spacer(modifier = Modifier.width(6.dp)); Text("Export") }
+            }
+            Button(
+                onClick = onSave,
+                enabled = !isSaving,
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.buttonColors(containerColor = VesperOrange)
+            ) {
+                if (isSaving) CircularProgressIndicator(modifier = Modifier.size(18.dp), color = Color.White, strokeWidth = 2.dp)
+                else Icon(Icons.Default.Save, null)
+                Spacer(modifier = Modifier.width(8.dp))
+                Text("Save to Flipper")
+            }
+
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
+                Text("LAYERS", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant, letterSpacing = 1.sp)
+                Box {
+                    TextButton(onClick = { addMenuOpen = true }) { Icon(Icons.Default.Add, null); Spacer(modifier = Modifier.width(4.dp)); Text("Add Layer") }
+                    DropdownMenu(expanded = addMenuOpen, onDismissRequest = { addMenuOpen = false }) {
+                        listOf(LayerType.CARRIER, LayerType.PREAMBLE, LayerType.SYNC, LayerType.DATA, LayerType.BURST).forEach { type ->
+                            DropdownMenuItem(text = { Text(type.displayName) }, onClick = { onAddLayer(type); addMenuOpen = false })
+                        }
+                    }
+                }
+            }
+
+            project.layers.forEachIndexed { index, layer ->
+                RfLayerRow(
+                    layer = layer,
+                    selected = index == selectedLayerIndex,
+                    canMoveUp = index > 0,
+                    canMoveDown = index < project.layers.lastIndex,
+                    onSelect = { onSelectLayer(index) },
+                    onToggle = { onToggleLayer(index) },
+                    onDuplicate = { onDuplicateLayer(index) },
+                    onMoveUp = { onMoveLayerUp(index) },
+                    onMoveDown = { onMoveLayerDown(index) },
+                    onRemove = { onRemoveLayer(index) }
+                )
+            }
+
+            selectedLayer?.let { layer ->
+                HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.2f))
+                Text("SELECTED: ${layer.name}", style = MaterialTheme.typography.labelSmall, color = VesperAccent, letterSpacing = 1.sp)
+                Text("Volume ${((layer.volume * 100).toInt())}%", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Slider(value = layer.volume, onValueChange = { onLayerVolumeChange(selectedLayerIndex, it) }, valueRange = 0f..1f)
+
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    OutlinedTextField(
+                        value = layer.pattern.bitDuration.toString(),
+                        onValueChange = { it.toIntOrNull()?.let { value -> onLayerBitDurationChange(selectedLayerIndex, value) } },
+                        label = { Text("Bit us") },
+                        modifier = Modifier.weight(1f),
+                        singleLine = true,
+                        colors = OutlinedTextFieldDefaults.colors(focusedBorderColor = VesperAccent, cursorColor = VesperAccent)
+                    )
+                    OutlinedTextField(
+                        value = layer.timing.repeatCount.toString(),
+                        onValueChange = { it.toIntOrNull()?.let { value -> onLayerRepeatCountChange(selectedLayerIndex, value) } },
+                        label = { Text("Repeats") },
+                        modifier = Modifier.weight(1f),
+                        singleLine = true,
+                        colors = OutlinedTextFieldDefaults.colors(focusedBorderColor = VesperAccent, cursorColor = VesperAccent)
+                    )
+                }
+
+                Box {
+                    OutlinedButton(onClick = { encodingMenuOpen = true }, modifier = Modifier.fillMaxWidth()) {
+                        Text(layer.pattern.encoding.displayName, modifier = Modifier.weight(1f), maxLines = 1, overflow = TextOverflow.Ellipsis)
+                        Icon(Icons.Default.ExpandMore, null)
+                    }
+                    DropdownMenu(expanded = encodingMenuOpen, onDismissRequest = { encodingMenuOpen = false }) {
+                        BitEncoding.entries.forEach { encoding ->
+                            DropdownMenuItem(
+                                text = { Text(encoding.displayName) },
+                                onClick = { onLayerEncodingChange(selectedLayerIndex, encoding); encodingMenuOpen = false }
+                            )
+                        }
+                    }
+                }
+
+                OutlinedTextField(
+                    value = bitsToHex(layer.pattern.bits),
+                    onValueChange = { onLayerBitsChange(selectedLayerIndex, it) },
+                    label = { Text("Bits as hex") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    textStyle = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
+                    colors = OutlinedTextFieldDefaults.colors(focusedBorderColor = VesperAccent, cursorColor = VesperAccent)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RfLayerRow(
+    layer: SignalLayer,
+    selected: Boolean,
+    canMoveUp: Boolean,
+    canMoveDown: Boolean,
+    onSelect: () -> Unit,
+    onToggle: () -> Unit,
+    onDuplicate: () -> Unit,
+    onMoveUp: () -> Unit,
+    onMoveDown: () -> Unit,
+    onRemove: () -> Unit
+) {
+    val color = Color(layer.color)
+    Surface(
+        modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(8.dp)).clickable(onClick = onSelect),
+        color = if (selected) color.copy(alpha = 0.18f) else MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+        border = BorderStroke(1.dp, if (selected) color else Color.Transparent),
+        shape = RoundedCornerShape(8.dp)
+    ) {
+        Row(modifier = Modifier.padding(8.dp), verticalAlignment = Alignment.CenterVertically) {
+            Switch(checked = layer.enabled, onCheckedChange = { onToggle() }, modifier = Modifier.size(width = 44.dp, height = 28.dp))
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(layer.type.icon, style = MaterialTheme.typography.titleMedium)
+            Spacer(modifier = Modifier.width(8.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(layer.name, color = Color.White, fontWeight = FontWeight.Medium, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                Text("${layer.pattern.bits.size} bits / ${layer.pattern.bitDuration}us / x${layer.timing.repeatCount}", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            IconButton(onClick = onMoveUp, enabled = canMoveUp, modifier = Modifier.size(32.dp)) { Icon(Icons.Default.ArrowUpward, null, modifier = Modifier.size(18.dp)) }
+            IconButton(onClick = onMoveDown, enabled = canMoveDown, modifier = Modifier.size(32.dp)) { Icon(Icons.Default.ArrowDownward, null, modifier = Modifier.size(18.dp)) }
+            IconButton(onClick = onDuplicate, modifier = Modifier.size(32.dp)) { Icon(Icons.Default.ContentCopy, null, modifier = Modifier.size(18.dp)) }
+            IconButton(onClick = onRemove, modifier = Modifier.size(32.dp)) { Icon(Icons.Default.Delete, null, tint = RiskHigh, modifier = Modifier.size(18.dp)) }
+        }
+    }
+}
+
+@Composable
+private fun RfWaveformPreview(samples: List<Float>, modifier: Modifier = Modifier) {
+    val waveColor = VesperAccent
+    val gridColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.18f)
+
+    Canvas(modifier = modifier.clip(RoundedCornerShape(8.dp)).background(Color(0xFF0A0E14))) {
+        val padding = 12f
+        val usableWidth = size.width - padding * 2
+        val usableHeight = size.height - padding * 2
+        repeat(5) { i ->
+            val y = padding + usableHeight * i / 4
+            drawLine(gridColor, Offset(padding, y), Offset(size.width - padding, y), strokeWidth = 1f)
+        }
+        if (samples.isEmpty()) return@Canvas
+
+        val path = Path()
+        samples.forEachIndexed { index, value ->
+            val x = padding + usableWidth * index / (samples.lastIndex.coerceAtLeast(1))
+            val y = padding + (1f - value.coerceIn(0f, 1f)) * usableHeight
+            if (index == 0) path.moveTo(x, y) else path.lineTo(x, y)
+        }
+        drawPath(path, color = waveColor, style = Stroke(width = 2.5f, cap = StrokeCap.Round, join = StrokeJoin.Round))
+    }
+}
+
+private fun bitsToHex(bits: List<Boolean>): String =
+    bits.chunked(4).joinToString("") { chunk ->
+        chunk.foldIndexed(0) { index, acc, bit -> if (bit) acc or (1 shl (3 - index)) else acc }
+            .toString(16)
+            .uppercase()
+    }
 
 // ═══════════════════════════════════════════════════════════
 // THE VAULT HEADER & FILTERS
@@ -593,7 +923,7 @@ private fun WorkbenchDialog(
                     }
                 }
 
-                Divider()
+                HorizontalDivider()
 
                 OutlinedTextField(
                     value = content,
@@ -610,6 +940,65 @@ private fun WorkbenchDialog(
 
                 Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     OutlinedButton(onClick = onDismiss, modifier = Modifier.weight(1f)) { Text("Cancel") }
+                    Button(
+                        onClick = onSave,
+                        modifier = Modifier.weight(1f),
+                        enabled = !isSaving,
+                        colors = ButtonDefaults.buttonColors(containerColor = VesperOrange)
+                    ) {
+                        if (isSaving) CircularProgressIndicator(modifier = Modifier.size(18.dp), color = Color.White, strokeWidth = 2.dp)
+                        else Icon(Icons.Default.Save, null)
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text("Save to Flipper")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ExportDialog(
+    content: String,
+    isSaving: Boolean,
+    onSave: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    Dialog(onDismissRequest = onDismiss) {
+        Card(
+            modifier = Modifier.fillMaxWidth().fillMaxHeight(0.85f),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+        ) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(Icons.Default.IosShare, null, tint = VesperOrange)
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text("EXPORT RAW", style = MaterialTheme.typography.labelLarge, color = VesperOrange, letterSpacing = 1.sp)
+                    }
+                    IconButton(onClick = onDismiss) { Icon(Icons.Default.Close, "Close") }
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+                Card(
+                    modifier = Modifier.fillMaxWidth().weight(1f),
+                    colors = CardDefaults.cardColors(containerColor = Color(0xFF0A0E14)),
+                    shape = RoundedCornerShape(8.dp)
+                ) {
+                    Box(modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(12.dp)) {
+                        Text(
+                            content,
+                            fontFamily = FontFamily.Monospace,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = VesperAccent.copy(alpha = 0.9f),
+                            fontSize = 11.sp
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    OutlinedButton(onClick = onDismiss, modifier = Modifier.weight(1f)) { Text("Close") }
                     Button(
                         onClick = onSave,
                         modifier = Modifier.weight(1f),

--- a/app/src/main/java/com/vesper/flipper/ui/screen/DeviceScreen.kt
+++ b/app/src/main/java/com/vesper/flipper/ui/screen/DeviceScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.vesper.flipper.BuildConfig
 import com.vesper.flipper.R
 import com.vesper.flipper.ble.CliCapabilityLevel
 import com.vesper.flipper.ble.CliCapabilityStatus
@@ -176,7 +177,8 @@ fun DeviceScreen(
                         isScanning = connectionState is ConnectionState.Scanning,
                         onStartScan = { viewModel.startScan() },
                         onStopScan = { viewModel.stopScan() },
-                        onConnectUsb = { viewModel.connectUsb() }
+                        onConnectUsb = { viewModel.connectUsb() },
+                        onConnectDesktopBridge = { viewModel.connectDesktopBridge() }
                     )
                 }
 
@@ -955,7 +957,8 @@ private fun ScanSection(
     isScanning: Boolean,
     onStartScan: () -> Unit,
     onStopScan: () -> Unit,
-    onConnectUsb: () -> Unit
+    onConnectUsb: () -> Unit,
+    onConnectDesktopBridge: () -> Unit
 ) {
     Column(
         modifier = Modifier.fillMaxWidth(),
@@ -990,6 +993,17 @@ private fun ScanSection(
             Icon(Icons.Default.Usb, contentDescription = null)
             Spacer(modifier = Modifier.width(8.dp))
             Text("Connect via USB")
+        }
+
+        if (BuildConfig.DEBUG) {
+            OutlinedButton(
+                onClick = onConnectDesktopBridge,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Icon(Icons.Default.DesktopWindows, contentDescription = null)
+                Spacer(modifier = Modifier.width(8.dp))
+                Text("Connect via Desktop Bridge")
+            }
         }
     }
 }

--- a/app/src/main/java/com/vesper/flipper/ui/viewmodel/AlchemyLabViewModel.kt
+++ b/app/src/main/java/com/vesper/flipper/ui/viewmodel/AlchemyLabViewModel.kt
@@ -178,6 +178,24 @@ class AlchemyLabViewModel @Inject constructor(
         }
     }
 
+    fun canOpenBlueprintInEditor(blueprint: ForgeBlueprint): Boolean =
+        blueprint.payloadType == PayloadType.SUB_GHZ &&
+            SignalAlchemist.canImportSubGhzRaw(blueprint.generatedCode)
+
+    fun openBlueprintInEditor() {
+        val blueprint = _currentBlueprint.value ?: return
+        val imported = SignalAlchemist.importSubGhzRaw(
+            content = blueprint.generatedCode,
+            name = blueprint.title
+        ) ?: run {
+            _message.value = "Only SubGHz RAW payloads can open in RF Editor"
+            return
+        }
+        _project.value = imported
+        _selectedLayerIndex.value = imported.layers.indices.firstOrNull()
+        _message.value = "Opened ${blueprint.title} in RF Editor"
+    }
+
     fun clearBlueprint() {
         _currentBlueprint.value = null
         _forgeInput.value = ""
@@ -377,13 +395,13 @@ class AlchemyLabViewModel @Inject constructor(
     fun selectLayer(index: Int?) { _selectedLayerIndex.value = index }
     fun toggleLayerEnabled(index: Int) { updateLayer(index) { it.copy(enabled = !it.enabled) } }
     fun updateLayerVolume(index: Int, volume: Float) { updateLayer(index) { it.copy(volume = volume.coerceIn(0f, 1f)) } }
-    fun updateLayerBitDuration(index: Int, duration: Int) { updateLayer(index) { l -> l.copy(pattern = l.pattern.copy(bitDuration = duration.coerceIn(50, 5000))) } }
-    fun updateLayerEncoding(index: Int, encoding: BitEncoding) { updateLayer(index) { l -> l.copy(pattern = l.pattern.copy(encoding = encoding)) } }
+    fun updateLayerBitDuration(index: Int, duration: Int) { updateLayer(index) { l -> l.copy(pattern = l.pattern.copy(bitDuration = duration.coerceIn(50, 5000)), rawTimings = null) } }
+    fun updateLayerEncoding(index: Int, encoding: BitEncoding) { updateLayer(index) { l -> l.copy(pattern = l.pattern.copy(encoding = encoding), rawTimings = null) } }
     fun updateLayerRepeatCount(index: Int, count: Int) { updateLayer(index) { l -> l.copy(timing = l.timing.copy(repeatCount = count.coerceIn(1, 100))) } }
     fun updateLayerBits(index: Int, hexPattern: String) {
         updateLayer(index) { layer ->
-            val bits = hexPattern.flatMap { char -> val nibble = char.toString().toIntOrNull(16) ?: 0; (3 downTo 0).map { (nibble shr it) and 1 == 1 } }
-            layer.copy(pattern = layer.pattern.copy(bits = bits))
+            val bits = hexPattern.filter { it.isDigit() || it.lowercaseChar() in 'a'..'f' }.flatMap { char -> val nibble = char.toString().toInt(16); (3 downTo 0).map { (nibble shr it) and 1 == 1 } }
+            layer.copy(pattern = layer.pattern.copy(bits = bits), rawTimings = null)
         }
     }
     fun moveLayerUp(index: Int) {
@@ -410,6 +428,7 @@ class AlchemyLabViewModel @Inject constructor(
                 val content = SignalAlchemist.exportToFlipperFormat(_project.value)
                 val filename = _project.value.name.replace(Regex("[^a-zA-Z0-9_-]"), "_").take(32)
                 val path = "/ext/subghz/alchemy_$filename.sub"
+                fileSystem.createDirectory(path.substringBeforeLast("/"))
                 val result = fileSystem.writeFile(path, content)
                 if (result.isSuccess) { _message.value = "Saved to $path"; _showExportDialog.value = false }
                 else _message.value = "Failed to save: ${result.exceptionOrNull()?.message}"

--- a/app/src/main/java/com/vesper/flipper/ui/viewmodel/DeviceViewModel.kt
+++ b/app/src/main/java/com/vesper/flipper/ui/viewmodel/DeviceViewModel.kt
@@ -160,6 +160,10 @@ class DeviceViewModel @Inject constructor(
         bleServiceManager.connectUsb()
     }
 
+    fun connectDesktopBridge() {
+        bleServiceManager.connectDesktopBridge()
+    }
+
     fun disconnect() {
         bleServiceManager.disconnect()
         _deviceInfo.value = null

--- a/app/src/main/java/com/vesper/flipper/ui/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/vesper/flipper/ui/viewmodel/SettingsViewModel.kt
@@ -199,9 +199,7 @@ class SettingsViewModel @Inject constructor(
             _isRefreshingModels.value = true
             openRouterModelCatalog.fetchLatestByManufacturer()
                 .onSuccess { models ->
-                    val merged = (
-                            models + SettingsStore.FALLBACK_MODELS.filter { it.id == SettingsStore.DEFAULT_MODEL }
-                            ).distinctBy { it.id }
+                    val merged = (models + SettingsStore.FALLBACK_MODELS).distinctBy { it.id }
                     _availableModels.value = merged
                 }
                 .onFailure {

--- a/app/src/test/java/com/vesper/flipper/ai/CommandParsingEdgeCaseTest.kt
+++ b/app/src/test/java/com/vesper/flipper/ai/CommandParsingEdgeCaseTest.kt
@@ -242,25 +242,24 @@ class CommandParsingEdgeCaseTest {
     @Test
     fun `fallback - args wrapped in single-element array`() {
         // Some models: "args": [{"path": "/ext"}]
-        val argsElement: JsonElement = JsonArray(listOf(
+        val argsArray = JsonArray(listOf(
             buildJsonObject { put("path", "/ext/nfc") }
         ))
 
-        val unwrapped = when {
-            argsElement is JsonArray && argsElement.size == 1 && argsElement[0] is JsonObject ->
-                argsElement[0] as JsonObject
-            else -> fail("Should have unwrapped single-element array")
+        if (argsArray.size != 1 || argsArray.first() !is JsonObject) {
+            fail("Should have unwrapped single-element array")
         }
+        val unwrapped = argsArray.first() as JsonObject
         assertEquals("/ext/nfc", unwrapped["path"]?.jsonPrimitive?.content)
     }
 
     @Test
     fun `fallback - args as empty array yields empty object`() {
-        val argsElement: JsonElement = JsonArray(emptyList())
-        val result = when {
-            argsElement is JsonArray && argsElement.isEmpty() -> JsonObject(emptyMap())
-            else -> fail("Should have produced empty JsonObject")
+        val argsArray = JsonArray(emptyList())
+        if (argsArray.isNotEmpty()) {
+            fail("Should have produced empty JsonObject")
         }
+        val result = JsonObject(emptyMap())
         assertTrue(result.isEmpty())
     }
 

--- a/app/src/test/java/com/vesper/flipper/ai/OpenRouterRequestSerializationTest.kt
+++ b/app/src/test/java/com/vesper/flipper/ai/OpenRouterRequestSerializationTest.kt
@@ -1,0 +1,30 @@
+package com.vesper.flipper.ai
+
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OpenRouterRequestSerializationTest {
+
+    private val json = Json {
+        encodeDefaults = true
+        explicitNulls = false
+    }
+
+    @Test
+    fun `serializes session id for auto-router stickiness`() {
+        val request = OpenRouterRequest(
+            model = "openrouter/auto",
+            messages = listOf(
+                OpenRouterMessage.text(role = "user", content = "ping")
+            ),
+            sessionId = "chat-session-123"
+        )
+
+        val encoded = json.encodeToString(request)
+
+        assertTrue(encoded.contains("\"model\":\"openrouter/auto\""))
+        assertTrue(encoded.contains("\"session_id\":\"chat-session-123\""))
+    }
+}

--- a/app/src/test/java/com/vesper/flipper/domain/CommandExecutorTest.kt
+++ b/app/src/test/java/com/vesper/flipper/domain/CommandExecutorTest.kt
@@ -1,7 +1,9 @@
 package com.vesper.flipper.domain
 
 import com.vesper.flipper.ble.FlipperFileSystem
+import com.vesper.flipper.data.SettingsStore
 import com.vesper.flipper.domain.executor.CommandExecutor
+import com.vesper.flipper.domain.executor.ForgeEngine
 import com.vesper.flipper.domain.executor.RiskAssessor
 import com.vesper.flipper.domain.model.AuditActionType
 import com.vesper.flipper.domain.model.AuditEntry
@@ -13,6 +15,7 @@ import com.vesper.flipper.domain.model.RiskLevel
 import com.vesper.flipper.domain.service.AuditService
 import com.vesper.flipper.domain.service.DiffService
 import com.vesper.flipper.domain.service.PermissionService
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -35,6 +38,8 @@ class CommandExecutorTest {
     private lateinit var permissionService: PermissionService
     private lateinit var auditService: AuditService
     private lateinit var diffService: DiffService
+    private lateinit var forgeEngine: ForgeEngine
+    private lateinit var settingsStore: SettingsStore
     private lateinit var commandExecutor: CommandExecutor
 
     @Before
@@ -44,12 +49,18 @@ class CommandExecutorTest {
         permissionService = mock()
         auditService = mock()
         diffService = mock()
+        forgeEngine = mock()
+        settingsStore = mock()
+        whenever(settingsStore.autoApproveMedium).thenReturn(flowOf(false))
+        whenever(settingsStore.autoApproveHigh).thenReturn(flowOf(false))
         commandExecutor = CommandExecutor(
             fileSystem = fileSystem,
             riskAssessor = riskAssessor,
             permissionService = permissionService,
             auditService = auditService,
-            diffService = diffService
+            diffService = diffService,
+            forgeEngine = forgeEngine,
+            settingsStore = settingsStore
         )
     }
 
@@ -183,7 +194,7 @@ class CommandExecutorTest {
     fun `search resources returns results`() = runBlocking {
         val command = ExecuteCommand(
             action = CommandAction.SEARCH_RESOURCES,
-            args = CommandArgs(command = "infrared", resourceType = "IR_REMOTE"),
+            args = CommandArgs(command = "Samsung", resourceType = "IR_REMOTE"),
             justification = "Find IR remote repos",
             expectedEffect = "Return matching resource repos"
         )

--- a/app/src/test/java/com/vesper/flipper/domain/SignalAlchemistTest.kt
+++ b/app/src/test/java/com/vesper/flipper/domain/SignalAlchemistTest.kt
@@ -1,0 +1,75 @@
+package com.vesper.flipper.domain
+
+import com.vesper.flipper.domain.model.*
+import org.junit.Assert.*
+import org.junit.Test
+
+class SignalAlchemistTest {
+
+    @Test
+    fun `export includes valid SubGHz RAW headers and data`() {
+        val content = SignalAlchemist.exportToFlipperFormat(sampleProject())
+
+        assertTrue(content.contains("Filetype: Flipper SubGhz RAW File"))
+        assertTrue(content.contains("Frequency: 433920000"))
+        assertTrue(content.contains("Preset: FuriHalSubGhzPresetOok650Async"))
+        assertTrue(content.contains("Protocol: RAW"))
+        assertTrue(content.contains("RAW_Data:"))
+    }
+
+    @Test
+    fun `import raw subghz reads frequency and data`() {
+        val content = """
+            Filetype: Flipper SubGhz RAW File
+            Version: 1
+            Frequency: 315000000
+            Preset: FuriHalSubGhzPresetOok270Async
+            Protocol: RAW
+            RAW_Data: 500 -500 1000 -500 500 -1000
+        """.trimIndent()
+
+        val project = SignalAlchemist.importSubGhzRaw(content, "Imported")
+
+        assertNotNull(project)
+        assertEquals("Imported", project!!.name)
+        assertEquals(315_000_000, project.frequency)
+        assertEquals(ModulationType.OOK_270, project.modulation)
+        assertEquals(1, project.layers.size)
+        assertEquals(listOf(true, false, true, false, true, false), project.layers.first().pattern.bits)
+        assertEquals(
+            listOf(500, -500, 1000, -500, 500, -1000),
+            SignalAlchemist.synthesize(project)
+        )
+    }
+
+    @Test
+    fun `import rejects non raw or malformed content`() {
+        assertNull(SignalAlchemist.importSubGhzRaw("Protocol: Princeton\nKey: 00 00"))
+        assertNull(SignalAlchemist.importSubGhzRaw("Protocol: RAW\nRAW_Data: 500 -500"))
+    }
+
+    @Test
+    fun `synthesis never emits zero timings when volume is zero`() {
+        val project = sampleProject().copy(
+            layers = sampleProject().layers.map { it.copy(volume = 0f) }
+        )
+
+        assertTrue(SignalAlchemist.synthesize(project).all { it != 0 })
+    }
+
+    private fun sampleProject() = AlchemyProject(
+        name = "Test Signal",
+        frequency = 433_920_000,
+        modulation = ModulationType.OOK_650,
+        preset = SignalPreset.CAR_KEY_433,
+        layers = listOf(
+            SignalLayer(
+                name = "Data",
+                type = LayerType.DATA,
+                pattern = BitPattern(listOf(true, false, true, false), bitDuration = 400),
+                timing = TimingConfig(),
+                color = 0xFFFF6B00
+            )
+        )
+    )
+}

--- a/local.properties
+++ b/local.properties
@@ -4,5 +4,6 @@
 # Location of the SDK. This is only used by Gradle.
 # For customization when using a Version Control System, please read the
 # header note.
-#Tue Jan 20 13:09:38 PST 2026
-sdk.dir=/Users/abraxas/Library/Android/sdk
+#Tue Jul 08 11:30:00 CEST 2026
+sdk.dir=/home/e/Android/Sdk
+OPENROUTER_DEFAULT_MODEL=openrouter/auto

--- a/local.properties
+++ b/local.properties
@@ -1,9 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Tue Jul 08 11:30:00 CEST 2026
-sdk.dir=/home/e/Android/Sdk
-OPENROUTER_DEFAULT_MODEL=openrouter/auto

--- a/tools/flipper_desktop_bridge.py
+++ b/tools/flipper_desktop_bridge.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Local TCP-to-Flipper USB bridge for Android emulator debug builds."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import selectors
+import socket
+import struct
+import sys
+import termios
+import time
+from pathlib import Path
+
+
+DEFAULT_BY_ID = Path("/dev/serial/by-id/usb-Flipper_Devices_Inc._Eledtive_flip_Eledtive-if00")
+DEFAULT_SERIAL = Path("/dev/ttyACM0")
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8765
+BAUD_CANDIDATES = (230400, 115200, 460800, 921600)
+RPC_PRIME_COMMANDS = (b"start_rpc_session\r", b"start_rpc_session\r\n", b"\n")
+MAX_FRAME = 1024 * 1024
+
+
+def encode_frame(payload: bytes) -> bytes:
+    if len(payload) > MAX_FRAME:
+        raise ValueError(f"frame too large: {len(payload)}")
+    return struct.pack(">I", len(payload)) + payload
+
+
+def pop_frames(buffer: bytearray) -> list[bytes]:
+    frames: list[bytes] = []
+    while len(buffer) >= 4:
+        size = struct.unpack(">I", buffer[:4])[0]
+        if size > MAX_FRAME:
+            raise ValueError(f"frame too large: {size}")
+        if len(buffer) < 4 + size:
+            break
+        frames.append(bytes(buffer[4 : 4 + size]))
+        del buffer[: 4 + size]
+    return frames
+
+
+def baud_constant(baud: int) -> int:
+    name = f"B{baud}"
+    if not hasattr(termios, name):
+        raise ValueError(f"unsupported baud rate by this platform: {baud}")
+    return getattr(termios, name)
+
+
+def configure_serial(fd: int, baud: int) -> None:
+    attrs = termios.tcgetattr(fd)
+    attrs[0] = 0
+    attrs[1] = 0
+    attrs[2] = termios.CLOCAL | termios.CREAD | termios.CS8
+    attrs[3] = 0
+    attrs[4] = baud_constant(baud)
+    attrs[5] = baud_constant(baud)
+    attrs[6][termios.VMIN] = 0
+    attrs[6][termios.VTIME] = 1
+    termios.tcsetattr(fd, termios.TCSANOW, attrs)
+
+
+def resolve_serial_path(requested: str | None) -> Path:
+    if requested:
+        return Path(requested)
+    if DEFAULT_BY_ID.exists():
+        return DEFAULT_BY_ID
+    return DEFAULT_SERIAL
+
+
+def open_serial(path: Path, baud: int) -> int:
+    fd = os.open(path, os.O_RDWR | os.O_NOCTTY | os.O_NONBLOCK)
+    configure_serial(fd, baud)
+    for command in RPC_PRIME_COMMANDS:
+        write_all_fd(fd, command)
+        time.sleep(0.08)
+    return fd
+
+
+def write_all_fd(fd: int, data: bytes) -> None:
+    view = memoryview(data)
+    while view:
+        try:
+            written = os.write(fd, view)
+        except BlockingIOError:
+            time.sleep(0.01)
+            continue
+        if written == 0:
+            raise OSError("serial write returned 0 bytes")
+        view = view[written:]
+
+
+def run_bridge(serial_path: Path, host: str, port: int, baud_candidates: tuple[int, ...]) -> None:
+    last_error: Exception | None = None
+    serial_fd: int | None = None
+    for baud in baud_candidates:
+        try:
+            serial_fd = open_serial(serial_path, baud)
+            print(f"serial {serial_path} open at {baud}", flush=True)
+            break
+        except OSError as exc:
+            last_error = exc
+        except ValueError as exc:
+            last_error = exc
+    if serial_fd is None:
+        raise SystemExit(f"failed to open serial {serial_path}: {last_error}")
+
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server:
+            server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            server.bind((host, port))
+            server.listen(1)
+            print(f"listening on {host}:{port}", flush=True)
+            while True:
+                client, addr = server.accept()
+                with client:
+                    print(f"client connected: {addr[0]}:{addr[1]}", flush=True)
+                    client.setblocking(False)
+                    os.set_blocking(serial_fd, False)
+                    pump(serial_fd, client)
+                    print("client disconnected", flush=True)
+    finally:
+        os.close(serial_fd)
+
+
+def pump(serial_fd: int, client: socket.socket) -> None:
+    selector = selectors.DefaultSelector()
+    selector.register(client, selectors.EVENT_READ, "client")
+    selector.register(serial_fd, selectors.EVENT_READ, "serial")
+    client_buffer = bytearray()
+
+    while True:
+        for key, _ in selector.select(timeout=1.0):
+            if key.data == "client":
+                chunk = client.recv(65536)
+                if not chunk:
+                    return
+                client_buffer.extend(chunk)
+                for frame in pop_frames(client_buffer):
+                    if frame:
+                        write_all_fd(serial_fd, frame)
+            else:
+                try:
+                    data = os.read(serial_fd, 4096)
+                except BlockingIOError:
+                    continue
+                if data:
+                    try:
+                        client.setblocking(True)
+                        client.sendall(encode_frame(data))
+                    finally:
+                        client.setblocking(False)
+
+
+def self_test() -> None:
+    payloads = [b"", b"abc", bytes(range(256))]
+    stream = bytearray().join(encode_frame(payload) for payload in payloads)
+    partial = bytearray(stream[:7])
+    assert pop_frames(partial) == [b""]
+    partial.extend(stream[7:])
+    assert pop_frames(partial) == payloads[1:]
+    assert partial == bytearray()
+    try:
+        pop_frames(bytearray(struct.pack(">I", MAX_FRAME + 1)))
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("oversized frame was accepted")
+    read_fd, write_fd = os.pipe()
+    try:
+        os.set_blocking(write_fd, False)
+        write_all_fd(write_fd, b"serial")
+        assert os.read(read_fd, 6) == b"serial"
+    finally:
+        os.close(read_fd)
+        os.close(write_fd)
+    print("self-test ok")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--serial", help="serial device path")
+    parser.add_argument("--host", default=DEFAULT_HOST)
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT)
+    parser.add_argument("--baud", type=int, choices=BAUD_CANDIDATES, help="single baud rate to try")
+    parser.add_argument("--self-test", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    if args.self_test:
+        self_test()
+        return 0
+    baud_candidates = (args.baud,) if args.baud else BAUD_CANDIDATES
+    run_bridge(resolve_serial_path(args.serial), args.host, args.port, baud_candidates)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## What changed
- adds the desktop bridge transport and RAW file import support
- adds unit tests for OpenRouter request serialization and signal alchemy behavior
- fixes the command parsing and executor tests so the unit test task passes again
- moves the `OPENROUTER_DEFAULT_MODEL` default into tracked Gradle config and stops tracking `local.properties`

## Why
The feature commit added a new OpenRouter default via `local.properties`, but that file is machine-local and should not be versioned. Keeping the default in code preserves the intended behavior without shipping workstation-specific SDK paths or local config.

## Impact
- desktop bridge and RAW import support are available in the app
- fresh builds default to `openrouter/auto` without requiring a committed `local.properties`
- contributors keep their own `local.properties` out of version control
- the unit test task is green again on this branch

## Validation
- `./gradlew :app:assembleDebug` ✅
- `./gradlew testDebugUnitTest` ✅
